### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete multi-character sanitization

### DIFF
--- a/src/app/lib/fs-blog.ts
+++ b/src/app/lib/fs-blog.ts
@@ -262,7 +262,12 @@ export function extractHeadingsFromContent(content: string): Heading[] {
   while ((match = headingRegex.exec(content)) !== null) {
     // If the heading doesn't have an ID, generate one from the content
     const level = parseInt(match[1]);
-    const text = match[3].replace(/<[^>]*>/g, ''); // Strip HTML tags inside heading
+    let text = match[3];
+    let previous;
+    do {
+      previous = text;
+      text = text.replace(/<[^>]*>/g, ''); // Strip HTML tags inside heading
+    } while (text !== previous);
     let id = match[2];
     
     // If no ID found, generate one from the text content


### PR DESCRIPTION
Potential fix for [https://github.com/coolguy1771/witl-xyz/security/code-scanning/11](https://github.com/coolguy1771/witl-xyz/security/code-scanning/11)

To fix the problem, we need to ensure that all HTML tags are completely removed from the heading text. One effective way to achieve this is to repeatedly apply the regular expression replacement until no more replacements can be performed. This ensures that nested or consecutive tags are fully removed.

We will modify the code in the `extractHeadingsFromContent` function to repeatedly apply the regular expression replacement on `match[3]` until no more replacements occur. This will ensure that all HTML tags are stripped from the heading text.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
