### PR TITLE
fix: sanitize markdown output, refactor Navbar, improve blog types and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Learned User Preferences
 
+- Current role: DevOps Engineer at CentralReach, building a developer microservices platform with Istio, AWS, ArgoCD, and Terraform. Previously Cisco (OpenShift CI/CD) and General Dynamics (air-gapped Kubernetes).
+
 - Use Bun for package management, scripts, and CI instead of npm, yarn, or pnpm.
 - Prefer minimal, surgical changes; verify review or audit findings against current code before fixing.
 - When addressing review feedback, fix only still-valid issues and skip the rest with a brief reason.

--- a/README.md
+++ b/README.md
@@ -47,15 +47,17 @@ Open [http://localhost:3000](http://localhost:3000) to see the result.
 ## Blog Posts
 
 Blog posts are written in Markdown and stored in the `posts` directory. Each
-post should include frontmatter with the following fields:
+Each post should include frontmatter with the following fields:
 
 ```markdown
 ---
-title: Your Post Title
-date: "2025-01-15"
-author: Your Name
-tags: ["nextjs", "react", "typescript"]
-excerpt: Optional custom excerpt for your post
+title: Your Post Title          # Required
+date: "2025-01-15"              # Required (ISO format or parseable)
+author: Your Name               # Optional
+tags: ["nextjs", "react"]       # Optional array of tags
+excerpt: Custom excerpt         # Optional; auto-generated if omitted
+coverImage: "/image.jpg"        # Optional URL/path to cover image
+featured: true                  # Optional boolean; featured posts show up in curated sections
 ---
 
 Your content here...

--- a/README.md
+++ b/README.md
@@ -47,13 +47,15 @@ Open [http://localhost:3000](http://localhost:3000) to see the result.
 ## Blog Posts
 
 Blog posts are written in Markdown and stored in the `posts` directory. Each
-Each post should include frontmatter with the following fields:
+post should include frontmatter with the following fields:
 
 ```markdown
 ---
 title: Your Post Title          # Required
 date: "2025-01-15"              # Required (ISO format or parseable)
-author: Your Name               # Optional
+author:                         # Optional
+  name: Your Name
+  # avatar: "/avatar.jpg"
 tags: ["nextjs", "react"]       # Optional array of tags
 excerpt: Custom excerpt         # Optional; auto-generated if omitted
 coverImage: "/image.jpg"        # Optional URL/path to cover image

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "react-icons": "^5.6.0",
         "rehype-autolink-headings": "^7.1.0",
         "rehype-highlight": "^7.0.2",
+        "rehype-sanitize": "^6.0.0",
         "rehype-slug": "^6.0.0",
         "rehype-stringify": "^10.0.1",
         "remark": "^15.0.1",
@@ -1542,6 +1543,8 @@
     "rehype-autolink-headings": ["rehype-autolink-headings@7.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "hast-util-heading-rank": "^3.0.0", "hast-util-is-element": "^3.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw=="],
 
     "rehype-highlight": ["rehype-highlight@7.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-to-text": "^4.0.0", "lowlight": "^3.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA=="],
+
+    "rehype-sanitize": ["rehype-sanitize@6.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-sanitize": "^5.0.0" } }, "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg=="],
 
     "rehype-slug": ["rehype-slug@6.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "github-slugger": "^2.0.0", "hast-util-heading-rank": "^3.0.0", "hast-util-to-string": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A=="],
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-icons": "^5.6.0",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-highlight": "^7.0.2",
+    "rehype-sanitize": "^6.0.0",
     "rehype-slug": "^6.0.0",
     "rehype-stringify": "^10.0.1",
     "remark": "^15.0.1",

--- a/posts/software-supply-chain.md
+++ b/posts/software-supply-chain.md
@@ -3,7 +3,8 @@ title:
   "The Hidden Threat: Software Supply Chain Vulnerabilities in Critical
   Infrastructure"
 date: "2025-03-08"
-author: "Tyler Witlin"
+author:
+  name: Tyler Witlin
 categories: ["Cybersecurity", "Critical Infrastructure", "Software Development"]
 tags: ["supply chain", "vulnerabilities", "security"]
 summary:

--- a/src/app/components/About.tsx
+++ b/src/app/components/About.tsx
@@ -78,8 +78,9 @@ export const AboutSection: React.FC = () => {
               >
                 Kubernetes
               </Box>{" "}
-              for a living. Right now that means CI/CD infrastructure at Cisco on OpenShift; before
-              that it was{" "}
+              for a living. Right now that means a developer microservices platform at CentralReach
+              with Istio, AWS, ArgoCD, and Terraform. Before that it was CI/CD on OpenShift at
+              Cisco, then{" "}
               <Box
                 component="span"
                 sx={{ color: theme.palette.primary.main, fontWeight: 600 }}

--- a/src/app/components/Hero.tsx
+++ b/src/app/components/Hero.tsx
@@ -12,13 +12,13 @@ const TERMINAL_LINES = [
   { type: "output", text: "Tyler Witlin" },
   { type: "blank", text: "" },
   { type: "prompt", text: "cat role.txt" },
-  { type: "output-highlight", text: "DevOps Engineer @ Cisco Systems" },
+  { type: "output-highlight", text: "DevOps Engineer @ CentralReach" },
   { type: "blank", text: "" },
   { type: "prompt", text: "kubectl get specialties --no-headers" },
-  { type: "output-green", text: "openshift    argocd    helm    golang    air-gapped" },
+  { type: "output-green", text: "istio    aws    argocd    terraform    kubernetes" },
   { type: "blank", text: "" },
   { type: "prompt", text: "git log --oneline -1" },
-  { type: "output", text: "built ci/cd on openshift for a lot of engineers" },
+  { type: "output", text: "developing a microservices platform for developers" },
 ];
 
 const CHAR_DELAY = 35;

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -24,6 +24,7 @@ import {
 import { Menu, X, Sun, Moon, ArrowUp } from "lucide-react";
 import { useThemeMode } from "./ThemeRegistry";
 import { useLenis } from "lenis/react";
+import { CODE_FONT_FAMILY } from "../lib/code-font";
 
 /** Scroll-direction tracking hook. Hides navbar on scroll down, shows on scroll up. */
 function useNavbarVisibility(isOpen: boolean) {
@@ -112,7 +113,7 @@ function NavLink({
         color: isActive ? theme.palette.primary.main : theme.palette.text.secondary,
         textDecoration: "none",
         fontWeight: isActive ? 600 : 400,
-        fontFamily: "'Geist Mono', monospace",
+        fontFamily: CODE_FONT_FAMILY,
         fontSize: "0.85rem",
         transition: "color 0.2s ease",
         "&:hover": {

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -3,42 +3,39 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { AppBar } from "@mui/material";
+import { AppBar, Container, Toolbar, Box, Typography, IconButton, useTheme, Theme, useMediaQuery, Drawer, Button, Fab, Tooltip, alpha, Zoom } from "@mui/material";
 import { Menu, X, Sun, Moon, ArrowUp } from "lucide-react";
-import {
-  Container,
-  Toolbar,
-  Box,
-  Typography,
-  IconButton,
-  useTheme,
-  useMediaQuery,
-  Drawer,
-  Button,
-  Fab,
-  Tooltip,
-  alpha,
-  Zoom,
-} from "@mui/material";
 import { useThemeMode } from "./ThemeRegistry";
 import { useLenis } from "lenis/react";
 
-/**
- * Top navigation bar component with responsive links, theme toggle, mobile drawer, and a scroll-to-top control.
- *
- * The component synchronizes a local `hash` state with window.location.hash, tracks page scroll to adjust elevation and reveal a scroll-to-top FAB, and renders desktop and mobile navigation (including anchor links) with active styling.
- *
- * @returns The rendered navbar React element
- */
-export default function Navbar() {
-  const pathname = usePathname();
-  const [isOpen, setIsOpen] = useState(false);
+/** Scroll-direction tracking hook. Hides navbar on scroll down, shows on scroll up. */
+function useNavbarVisibility(isOpen: boolean) {
   const [scrolled, setScrolled] = useState(false);
   const [navVisible, setNavVisible] = useState(true);
+  const isMobile = useMediaQuery(useTheme().breakpoints.down("md"));
+
+  useLenis((instance) => {
+    setScrolled(instance.scroll > 60);
+
+    if (isOpen || isMobile || instance.scroll <= 0) {
+      setNavVisible(true);
+      return;
+    }
+
+    if (instance.direction === 1) {
+      setNavVisible(false);
+    } else if (instance.direction === -1) {
+      setNavVisible(true);
+    }
+  });
+
+  return { scrolled, navVisible };
+}
+
+/** Hash sync hook: keeps local hash in line with window.location.hash. */
+function useHash() {
+  const pathname = usePathname();
   const [hash, setHash] = useState("");
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
-  const lenis = useLenis();
 
   useEffect(() => {
     const syncHash = () => setHash(window.location.hash);
@@ -51,91 +48,218 @@ export default function Navbar() {
     };
   }, [pathname]);
 
-  useLenis((instance) => {
-    setScrolled(instance.scroll > 60);
+  return hash;
+}
 
-    if (isMobile || instance.scroll <= 0) {
-      setNavVisible(true);
-      return;
-    }
+const NAV_ITEMS = [
+  { label: "~/", href: "/" },
+  { label: "skills", href: "/#skills" },
+  { label: "certs", href: "/#certs" },
+  { label: "projects", href: "/#projects" },
+  { label: "blog", href: "/blog" },
+  { label: "about", href: "/#about" },
+  { label: "contact", href: "/#contact" },
+] as const;
 
-    if (instance.direction === 1) {
-      setNavVisible(false);
-    } else if (instance.direction === -1) {
-      setNavVisible(true);
-    }
-  });
+/** Desktop/mobile navigation link with underline and active-state logic. */
+function NavLink({ item, hash }: { item: typeof NAV_ITEMS[number]; hash: string }) {
+  const pathname = usePathname();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+
+  const linkHash = item.href.includes("#")
+    ? item.href.slice(item.href.indexOf("#"))
+    : "";
+  const isActive =
+    (item.href === "/" && pathname === "/" && !hash) ||
+    (pathname === "/" && linkHash !== "" && hash === linkHash) ||
+    (item.href === "/blog" && pathname.startsWith("/blog"));
+
+  return (
+    <Box
+      component={Link}
+      href={item.href}
+      sx={{
+        position: "relative",
+        color: isActive ? theme.palette.primary.main : theme.palette.text.secondary,
+        textDecoration: "none",
+        fontWeight: isActive ? 600 : 400,
+        fontFamily: "'Geist Mono', monospace",
+        fontSize: "0.85rem",
+        transition: "color 0.2s ease",
+        "&:hover": {
+          color: theme.palette.primary.main,
+          "&::after": {
+            width: "100%",
+          },
+        },
+        "&::after": {
+          content: '""',
+          position: "absolute",
+          bottom: -4,
+          left: 0,
+          width: isActive ? "100%" : 0,
+          height: "1px",
+          backgroundColor: theme.palette.primary.main,
+          transition: "width 0.2s ease",
+        },
+      }}
+      onClick={() => isMobile && window.history.back()} // drawer close handled outside
+    >
+      {item.label}
+    </Box>
+  );
+}
+
+/** Theme toggle button used in desktop navbar and mobile drawer. */
+function ThemeToggleButton({ onToggle }: { onToggle: () => void }) {
+  const theme = useTheme();
+  const { mode } = useThemeMode();
+  const icon = mode === "dark" ? <Sun size={18} /> : <Moon size={18} />;
+
+  return (
+    <Tooltip
+      title={`Switch to ${mode === "dark" ? "light" : "dark"} mode`}
+      arrow
+    >
+      <IconButton
+        onClick={onToggle}
+        sx={{
+          ml: 1,
+          bgcolor: (t) => alpha(t.palette.primary.main, 0.1),
+          color: "primary.main",
+          "&:hover": {
+            bgcolor: (t) => alpha(t.palette.primary.main, 0.2),
+            transform: "rotate(12deg)",
+          },
+          height: 36,
+          width: 36,
+        }}
+      >
+        {icon}
+      </IconButton>
+    </Tooltip>
+  );
+}
+
+/** Mobile drawer with nav links and theme toggle. */
+function MobileNavDrawer({
+  open,
+  onClose,
+  hash,
+}: {
+  open: boolean;
+  onClose: () => void;
+  hash: string;
+}) {
+  const theme = useTheme();
+  const { mode, toggleTheme } = useThemeMode();
+
+  return (
+    <Drawer
+      anchor="top"
+      open={open}
+      onClose={onClose}
+      transitionDuration={200}
+      slotProps={{
+        backdrop: {
+          sx: {
+            backdropFilter: "blur(8px)",
+            backgroundColor: theme.palette.background.default + "A6",
+          },
+        },
+        paper: {
+          sx: {
+            mt: { xs: "64px", md: "72px" },
+            boxShadow: "none",
+            backgroundColor: theme.palette.background.paper,
+          },
+        },
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 2,
+          py: 4,
+          px: 2,
+        }}
+      >
+        {NAV_ITEMS.map((item) => (
+          <NavLink key={item.href} item={item} hash={hash} />
+        ))}
+
+        {/* Theme toggle in mobile menu */}
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            mt: 2,
+            pt: 2,
+            borderTop: 1,
+            borderColor: "divider",
+          }}
+        >
+          <Button
+            onClick={() => {
+              toggleTheme();
+              onClose();
+            }}
+            startIcon={mode === "dark" ? <Sun size={16} /> : <Moon size={16} />}
+            variant="outlined"
+            color="primary"
+            size="small"
+          >
+            Switch to {mode === "dark" ? "light" : "dark"} mode
+          </Button>
+        </Box>
+      </Box>
+    </Drawer>
+  );
+}
+
+/**
+ * Top navigation bar component with responsive links, theme toggle, mobile drawer, and a scroll-to-top control.
+ */
+export default function Navbar() {
+  const [isOpen, setIsOpen] = useState(false);
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+  const hash = useHash();
+  const lenis = useLenis();
+  const { toggleTheme } = useThemeMode();
+
+  // Use extracted visibility logic; pass isOpen so it's aware of drawer state.
+  const { scrolled, navVisible } = useNavbarVisibility(isOpen);
 
   useEffect(() => {
-    if (!lenis) {
-      return;
-    }
-
+    if (!lenis) return;
     if (isOpen) {
       lenis.stop();
-      return;
+    } else {
+      lenis.start();
     }
-
-    lenis.start();
   }, [isOpen, lenis]);
 
-  const navItems = [
-    { label: "~/", href: "/" },
-    { label: "skills", href: "/#skills" },
-    { label: "certs", href: "/#certs" },
-    { label: "projects", href: "/#projects" },
-    { label: "blog", href: "/blog" },
-    { label: "about", href: "/#about" },
-    { label: "contact", href: "/#contact" },
-  ];
-
-  const NavLink = ({ item }: { item: { label: string; href: string } }) => {
-    const linkHash = item.href.includes("#")
-      ? item.href.slice(item.href.indexOf("#"))
-      : "";
-    const isActive =
-      (item.href === "/" && pathname === "/" && !hash) ||
-      (pathname === "/" && linkHash !== "" && hash === linkHash) ||
-      (item.href === "/blog" && pathname.startsWith("/blog"));
-
-    return (
-      <Box
-        component={Link}
-        href={item.href}
-        sx={{
-          position: "relative",
-          color: isActive ? theme.palette.primary.main : theme.palette.text.secondary,
-          textDecoration: "none",
-          fontWeight: isActive ? 600 : 400,
-          fontFamily: "'Geist Mono', monospace",
-          fontSize: "0.85rem",
-          transition: "color 0.2s ease",
-          "&:hover": {
-            color: theme.palette.primary.main,
-            "&::after": {
-              width: "100%",
-            },
-          },
-          "&::after": {
-            content: '""',
-            position: "absolute",
-            bottom: -4,
-            left: 0,
-            width: isActive ? "100%" : 0,
-            height: "1px",
-            backgroundColor: theme.palette.primary.main,
-            transition: "width 0.2s ease",
-          },
-        }}
-        onClick={() => isMobile && setIsOpen(false)}
-      >
-        {item.label}
-      </Box>
-    );
-  };
-
-  // Import theme context to allow theme toggling
-  const { mode, toggleTheme } = useThemeMode();
+  // AppBar styling
+  const appBarSx: ThemePropsFn<Theme> = () => ({
+    position: "static" as const,
+    elevation: scrolled ? 4 : 0,
+    backgroundColor: theme.palette.mode === "dark" ? "#0a0e14" : "#f0f4f8",
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    backdropFilter: "none",
+    transition: "all 0.3s ease",
+    zIndex: theme.zIndex.drawer + 1,
+    height: { xs: "64px", md: "72px" },
+    borderRadius: 0,
+    boxSizing: "border-box",
+    width: "100%",
+    left: 0,
+    right: 0,
+    boxShadow: "none",
+  });
 
   return (
     <>
@@ -151,281 +275,69 @@ export default function Navbar() {
           transition: "transform 0.3s ease",
         }}
       >
-          <AppBar
-            position="static"
-            elevation={scrolled ? 4 : 0}
-            sx={(theme) => ({
-              backgroundColor:
-                theme.palette.mode === "dark" ? "#0a0e14" : "#f0f4f8",
-              borderBottom: `1px solid ${theme.palette.divider}`,
-              backdropFilter: "none",
-              transition: "all 0.3s ease",
-              zIndex: theme.zIndex.drawer + 1,
-              height: { xs: "64px", md: "72px" },
-              borderRadius: 0,
-              boxSizing: "border-box",
-              width: "100%",
-              left: 0,
-              right: 0,
-              boxShadow: "none",
-            })}
-          >
-            <Container maxWidth="lg">
-              <Toolbar
-                disableGutters
-                sx={{
-                  px: { xs: 2, sm: 3 },
-                  py: { xs: 1.5, md: 2 },
-                  minHeight: { xs: "64px", md: "72px" },
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                }}
-              >
-                {/* Logo */}
-                <Box
-                  sx={{
-                    display: "flex",
-                    alignItems: "center",
-                  }}
-                >
-                  <Typography
-                    component={Link}
-                    href="/"
-                    variant="h6"
-                    sx={(theme) => ({
-                      color: theme.palette.secondary.main,
-                      textDecoration: "none",
-                      transition: "color 0.2s ease",
-                      fontSize: { xs: "1rem", md: "1.1rem" },
-                      letterSpacing: "0.01em",
-                      fontFamily: "'Geist Mono', monospace",
-                      fontWeight: "bold",
-                      "&:hover": {
-                        color: theme.palette.primary.main,
-                      },
-                    })}
-                  >
-                    witl@xyz:~$
-                  </Typography>
-                </Box>
-
-                {/* Desktop Navigation */}
-                <Box
-                  sx={{
-                    display: { xs: "none", md: "flex" },
-                    gap: 4,
-                    alignItems: "center",
-                  }}
-                >
-                  {navItems.map((item) => (
-                    <NavLink key={item.href} item={item} />
-                  ))}
-
-                  {/* Theme toggle button with animation */}
-                  <Tooltip
-                    title={
-                      <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-                        <span>Switch to {mode === "dark" ? "light" : "dark"} mode</span>
-                        {mode === "dark" ? (
-                          <Sun size={14} style={{ animation: "spin 1.5s ease infinite" }} />
-                        ) : (
-                          <Moon size={14} style={{ animation: "pulse 1.5s ease infinite" }} />
-                        )}
-                      </Box>
-                    }
-                    arrow
-                  >
-                    <IconButton
-                      onClick={toggleTheme}
-                      sx={{
-                        ml: 1,
-                        bgcolor: (theme) => alpha(theme.palette.primary.main, 0.1),
-                        color: "primary.main",
-                        "&:hover": {
-                          bgcolor: (theme) => alpha(theme.palette.primary.main, 0.2),
-                          transform: "rotate(12deg)",
-                        },
-                        height: 36,
-                        width: 36,
-                        transition: "all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1)", // Bouncy transition
-                        position: "relative",
-                        overflow: "hidden",
-                        "&::before": {
-                          content: '""',
-                          position: "absolute",
-                          width: "100%",
-                          height: "100%",
-                          backgroundColor: (theme) => alpha(theme.palette.primary.main, 0.1),
-                          borderRadius: "50%",
-                          top: 0,
-                          left: 0,
-                          transform: "scale(0)",
-                          transition: "transform 0.4s ease",
-                        },
-                        "&:active::before": {
-                          transform: "scale(2)",
-                          opacity: 0,
-                          transition: "transform 0.3s ease, opacity 0.3s ease",
-                        },
-                      }}
-                    >
-                      {mode === "dark" ? (
-                        <Sun
-                          size={18}
-                          style={{
-                            animation: "fadeIn 0.3s ease",
-                          }}
-                        />
-                      ) : (
-                        <Moon
-                          size={18}
-                          style={{
-                            animation: "fadeIn 0.3s ease",
-                          }}
-                        />
-                      )}
-                    </IconButton>
-                  </Tooltip>
-                </Box>
-
-                {/* Mobile Menu Button */}
-                <IconButton
-                  sx={{
-                    ml: "auto",
-                    display: { md: "none" },
-                    color: theme.palette.text.primary,
-                    width: 44,
-                    height: 44,
-                  }}
-                  onClick={() => setIsOpen(!isOpen)}
-                  edge="end"
-                  aria-label={isOpen ? "Close navigation menu" : "Open navigation menu"}
-                  aria-expanded={isOpen}
-                >
-                  {isOpen ? <X size={24} /> : <Menu size={24} />}
-                </IconButton>
-              </Toolbar>
-            </Container>
-
-            {/* Mobile Navigation */}
-            <Drawer
-              anchor="top"
-              open={isOpen && isMobile}
-              onClose={() => setIsOpen(false)}
-              transitionDuration={200}
-              slotProps={{
-                backdrop: {
-                  sx: {
-                    backdropFilter: "blur(8px)",
-                    backgroundColor: theme.palette.background.default + "A6",
-                  },
-                },
-                paper: {
-                  sx: {
-                    mt: { xs: "64px", md: "72px" },
-                    boxShadow: "none",
-                    backgroundColor: theme.palette.background.paper,
-                    transition: "background-color 0.3s ease",
-                  },
-                },
+        <AppBar sx={appBarSx}>
+          <Container maxWidth="lg">
+            <Toolbar
+              disableGutters
+              sx={{
+                px: { xs: 2, sm: 3 },
+                py: { xs: 1.5, md: 2 },
+                minHeight: { xs: "64px", md: "72px" },
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
               }}
             >
-              <Box
-                sx={{
-                  display: "flex",
-                  flexDirection: "column",
-                  gap: 2,
-                  py: 4,
-                  px: 2,
-                }}
+              {/* Logo */}
+              <Typography
+                component={Link}
+                href="/"
+                variant="h6"
+                sx={(theme) => ({
+                  color: theme.palette.secondary.main,
+                  textDecoration: "none",
+                  transition: "color 0.2s ease",
+                  fontSize: { xs: "1rem", md: "1.1rem" },
+                  letterSpacing: "0.01em",
+                  fontFamily: "'Geist Mono', monospace",
+                  fontWeight: "bold",
+                  "&:hover": { color: theme.palette.primary.main },
+                })}
               >
-                {navItems.map((item) => (
-                  <NavLink key={item.href} item={item} />
+                witl@xyz:~$
+              </Typography>
+
+              {/* Desktop Navigation */}
+              <Box sx={{ display: { xs: "none", md: "flex" }, gap: 4, alignItems: "center" }}>
+                {NAV_ITEMS.map((item) => (
+                  <NavLink key={item.href} item={item} hash={hash} />
                 ))}
 
-                {/* Theme toggle in mobile menu */}
-                <Box
-                  sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    mt: 2,
-                    pt: 2,
-                    borderTop: 1,
-                    borderColor: "divider",
-                  }}
-                >
-                  <Button
-                    onClick={() => {
-                      toggleTheme();
-                      setIsOpen(false);
-                    }}
-                    startIcon={
-                      mode === "dark" ? (
-                        <Sun
-                          size={16}
-                          style={{
-                            animation: "fadeIn 0.3s ease",
-                            transform: "rotate(0deg)",
-                            transformOrigin: "center",
-                          }}
-                        />
-                      ) : (
-                        <Moon
-                          size={16}
-                          style={{
-                            animation: "fadeIn 0.3s ease",
-                            transform: "rotate(0deg)",
-                            transformOrigin: "center",
-                          }}
-                        />
-                      )
-                    }
-                    variant="outlined"
-                    color="primary"
-                    size="small"
-                    sx={{
-                      mt: 1,
-                      position: "relative",
-                      overflow: "hidden",
-                      transition: "all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1)",
-                      "&:hover": {
-                        transform: "translateY(-3px)",
-                        boxShadow: (theme) =>
-                          `0 4px 8px ${alpha(theme.palette.primary.main, 0.25)}`,
-                      },
-                      "&::after": {
-                        content: '""',
-                        position: "absolute",
-                        width: "100%",
-                        height: "100%",
-                        background: (theme) => `linear-gradient(90deg,
-                        ${alpha(theme.palette.primary.main, 0)},
-                        ${alpha(theme.palette.primary.main, 0.1)},
-                        ${alpha(theme.palette.primary.main, 0)})`,
-                        top: 0,
-                        left: "-100%",
-                        transition: "left 0.5s ease",
-                      },
-                      "&:hover::after": {
-                        left: "100%",
-                      },
-                    }}
-                  >
-                    <span
-                      style={{
-                        display: "inline-block",
-                        animation: "fadeIn 0.5s ease",
-                      }}
-                    >
-                      Switch to {mode === "dark" ? "light" : "dark"} mode
-                    </span>
-                  </Button>
-                </Box>
+                <ThemeToggleButton onToggle={toggleTheme} />
               </Box>
-            </Drawer>
-          </AppBar>
+
+              {/* Mobile Menu Button */}
+              <IconButton
+                sx={{
+                  ml: "auto",
+                  display: { md: "none" },
+                  color: theme.palette.text.primary,
+                  width: 44,
+                  height: 44,
+                }}
+                onClick={() => setIsOpen((v) => !v)}
+                edge="end"
+                aria-label={isOpen ? "Close navigation menu" : "Open navigation menu"}
+                aria-expanded={isOpen}
+              >
+                {isOpen ? <X size={24} /> : <Menu size={24} />}
+              </IconButton>
+            </Toolbar>
+          </Container>
+
+          {/* Mobile Navigation */}
+          <MobileNavDrawer open={isOpen && isMobile} onClose={() => setIsOpen(false)} hash={hash} />
+        </AppBar>
       </Box>
 
       {/* Scroll to top button */}

--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -3,7 +3,24 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { AppBar, Container, Toolbar, Box, Typography, IconButton, useTheme, Theme, useMediaQuery, Drawer, Button, Fab, Tooltip, alpha, Zoom } from "@mui/material";
+import {
+  AppBar,
+  Container,
+  Toolbar,
+  Box,
+  Typography,
+  IconButton,
+  useTheme,
+  Theme,
+  useMediaQuery,
+  Drawer,
+  Button,
+  Fab,
+  Tooltip,
+  alpha,
+  Zoom,
+  SxProps,
+} from "@mui/material";
 import { Menu, X, Sun, Moon, ArrowUp } from "lucide-react";
 import { useThemeMode } from "./ThemeRegistry";
 import { useLenis } from "lenis/react";
@@ -12,7 +29,9 @@ import { useLenis } from "lenis/react";
 function useNavbarVisibility(isOpen: boolean) {
   const [scrolled, setScrolled] = useState(false);
   const [navVisible, setNavVisible] = useState(true);
-  const isMobile = useMediaQuery(useTheme().breakpoints.down("md"));
+  const isMobile = useMediaQuery(useTheme().breakpoints.down("md"), {
+    noSsr: true,
+  });
 
   useLenis((instance) => {
     setScrolled(instance.scroll > 60);
@@ -48,7 +67,7 @@ function useHash() {
     };
   }, [pathname]);
 
-  return hash;
+  return { hash, setHash };
 }
 
 const NAV_ITEMS = [
@@ -62,10 +81,19 @@ const NAV_ITEMS = [
 ] as const;
 
 /** Desktop/mobile navigation link with underline and active-state logic. */
-function NavLink({ item, hash }: { item: typeof NAV_ITEMS[number]; hash: string }) {
+function NavLink({
+  item,
+  hash,
+  onNavigate,
+  onHashChange,
+}: {
+  item: (typeof NAV_ITEMS)[number];
+  hash: string;
+  onNavigate?: () => void;
+  onHashChange: (nextHash: string) => void;
+}) {
   const pathname = usePathname();
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
 
   const linkHash = item.href.includes("#")
     ? item.href.slice(item.href.indexOf("#"))
@@ -104,7 +132,10 @@ function NavLink({ item, hash }: { item: typeof NAV_ITEMS[number]; hash: string 
           transition: "width 0.2s ease",
         },
       }}
-      onClick={() => isMobile && window.history.back()} // drawer close handled outside
+      onClick={() => {
+        onHashChange(linkHash);
+        onNavigate?.();
+      }}
     >
       {item.label}
     </Box>
@@ -112,18 +143,16 @@ function NavLink({ item, hash }: { item: typeof NAV_ITEMS[number]; hash: string 
 }
 
 /** Theme toggle button used in desktop navbar and mobile drawer. */
-function ThemeToggleButton({ onToggle }: { onToggle: () => void }) {
-  const theme = useTheme();
-  const { mode } = useThemeMode();
+function ThemeToggleButton() {
+  const { mode, toggleTheme } = useThemeMode();
   const icon = mode === "dark" ? <Sun size={18} /> : <Moon size={18} />;
+  const nextMode = mode === "dark" ? "light" : "dark";
 
   return (
-    <Tooltip
-      title={`Switch to ${mode === "dark" ? "light" : "dark"} mode`}
-      arrow
-    >
+    <Tooltip title={`Switch to ${nextMode} mode`} arrow>
       <IconButton
-        onClick={onToggle}
+        onClick={toggleTheme}
+        aria-label={`Switch to ${nextMode} mode`}
         sx={{
           ml: 1,
           bgcolor: (t) => alpha(t.palette.primary.main, 0.1),
@@ -147,10 +176,12 @@ function MobileNavDrawer({
   open,
   onClose,
   hash,
+  onHashChange,
 }: {
   open: boolean;
   onClose: () => void;
   hash: string;
+  onHashChange: (nextHash: string) => void;
 }) {
   const theme = useTheme();
   const { mode, toggleTheme } = useThemeMode();
@@ -187,7 +218,13 @@ function MobileNavDrawer({
         }}
       >
         {NAV_ITEMS.map((item) => (
-          <NavLink key={item.href} item={item} hash={hash} />
+          <NavLink
+            key={item.href}
+            item={item}
+            hash={hash}
+            onNavigate={onClose}
+            onHashChange={onHashChange}
+          />
         ))}
 
         {/* Theme toggle in mobile menu */}
@@ -226,27 +263,30 @@ function MobileNavDrawer({
 export default function Navbar() {
   const [isOpen, setIsOpen] = useState(false);
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("md"));
-  const hash = useHash();
+  const isMobile = useMediaQuery(theme.breakpoints.down("md"), { noSsr: true });
+  const { hash, setHash } = useHash();
   const lenis = useLenis();
-  const { toggleTheme } = useThemeMode();
 
-  // Use extracted visibility logic; pass isOpen so it's aware of drawer state.
   const { scrolled, navVisible } = useNavbarVisibility(isOpen);
+
+  const drawerOpen = isOpen && isMobile;
+
+  useEffect(() => {
+    if (!isMobile) {
+      setIsOpen(false);
+    }
+  }, [isMobile]);
 
   useEffect(() => {
     if (!lenis) return;
-    if (isOpen) {
+    if (drawerOpen) {
       lenis.stop();
     } else {
       lenis.start();
     }
-  }, [isOpen, lenis]);
+  }, [drawerOpen, lenis]);
 
-  // AppBar styling
-  const appBarSx: ThemePropsFn<Theme> = () => ({
-    position: "static" as const,
-    elevation: scrolled ? 4 : 0,
+  const appBarSx: SxProps<Theme> = {
     backgroundColor: theme.palette.mode === "dark" ? "#0a0e14" : "#f0f4f8",
     borderBottom: `1px solid ${theme.palette.divider}`,
     backdropFilter: "none",
@@ -258,8 +298,7 @@ export default function Navbar() {
     width: "100%",
     left: 0,
     right: 0,
-    boxShadow: "none",
-  });
+  };
 
   return (
     <>
@@ -275,7 +314,7 @@ export default function Navbar() {
           transition: "transform 0.3s ease",
         }}
       >
-        <AppBar sx={appBarSx}>
+        <AppBar position="static" elevation={scrolled ? 4 : 0} sx={appBarSx}>
           <Container maxWidth="lg">
             <Toolbar
               disableGutters
@@ -310,10 +349,15 @@ export default function Navbar() {
               {/* Desktop Navigation */}
               <Box sx={{ display: { xs: "none", md: "flex" }, gap: 4, alignItems: "center" }}>
                 {NAV_ITEMS.map((item) => (
-                  <NavLink key={item.href} item={item} hash={hash} />
+                  <NavLink
+                    key={item.href}
+                    item={item}
+                    hash={hash}
+                    onHashChange={setHash}
+                  />
                 ))}
 
-                <ThemeToggleButton onToggle={toggleTheme} />
+                <ThemeToggleButton />
               </Box>
 
               {/* Mobile Menu Button */}
@@ -327,16 +371,21 @@ export default function Navbar() {
                 }}
                 onClick={() => setIsOpen((v) => !v)}
                 edge="end"
-                aria-label={isOpen ? "Close navigation menu" : "Open navigation menu"}
-                aria-expanded={isOpen}
+                aria-label={drawerOpen ? "Close navigation menu" : "Open navigation menu"}
+                aria-expanded={drawerOpen}
               >
-                {isOpen ? <X size={24} /> : <Menu size={24} />}
+                {drawerOpen ? <X size={24} /> : <Menu size={24} />}
               </IconButton>
             </Toolbar>
           </Container>
 
           {/* Mobile Navigation */}
-          <MobileNavDrawer open={isOpen && isMobile} onClose={() => setIsOpen(false)} hash={hash} />
+          <MobileNavDrawer
+            open={drawerOpen}
+            onClose={() => setIsOpen(false)}
+            hash={hash}
+            onHashChange={setHash}
+          />
         </AppBar>
       </Box>
 

--- a/src/app/components/SkillsGrid.tsx
+++ b/src/app/components/SkillsGrid.tsx
@@ -9,7 +9,7 @@ import { MotionBox } from "./motion-ui";
 const SKILL_CATEGORIES = [
   {
     label: "// orchestration",
-    skills: ["Kubernetes", "OpenShift", "Helm", "Docker", "Kustomize"],
+    skills: ["Kubernetes", "Istio", "OpenShift", "Helm", "Docker", "Kustomize"],
   },
   {
     label: "// iac & config",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,7 +23,7 @@ const geistMono = localFont({
 export const metadata: Metadata = {
   title: "Tyler Witlin - DevOps Engineer",
   description:
-    "DevOps Engineer specializing in Kubernetes, GitOps, CI/CD pipelines, and cloud-native infrastructure. CKA certified.",
+    "DevOps Engineer at CentralReach building a developer microservices platform with Istio, AWS, ArgoCD, and Terraform. CKA certified.",
 };
 
 export const viewport: Viewport = {

--- a/src/app/lib/blog-markdown.test.ts
+++ b/src/app/lib/blog-markdown.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
+  applyHeadingIds,
+  HastNode,
   markdownToHtml,
   normalizeAuthor,
   slugify,
@@ -17,6 +19,46 @@ describe("markdownToHtml", () => {
     expect(html).toContain("Body");
     expect(html).not.toContain("<script");
     expect(html).not.toContain("alert(1)");
+  });
+
+  test("uses uniqueSlug for missing heading ids", async () => {
+    const html = await markdownToHtml("## Usage\n\n## Usage\n\n## Café\n\n## !!!");
+
+    expect(html).toContain('id="usage"');
+    expect(html).toContain('id="usage-2"');
+    expect(html).toContain('id="cafe"');
+    expect(html).toContain('id="section"');
+  });
+
+  test("preserves existing heading ids", () => {
+    const tree: HastNode = {
+      type: "root",
+      children: [
+        {
+          type: "element",
+          tagName: "h2",
+          properties: { id: "custom-id" },
+          children: [{ type: "text", value: "Hello" }],
+        },
+        {
+          type: "element",
+          tagName: "h2",
+          properties: {},
+          children: [{ type: "text", value: "Hello" }],
+        },
+      ],
+    };
+
+    applyHeadingIds(tree);
+
+    expect(tree.children?.[0].properties?.id).toBe("custom-id");
+    expect(tree.children?.[1].properties?.id).toBe("hello");
+  });
+
+  test("adds highlight.js classes to fenced code", async () => {
+    const html = await markdownToHtml("```js\nconst x = 1;\n```");
+
+    expect(html).toContain("hljs");
   });
 });
 

--- a/src/app/lib/blog-markdown.test.ts
+++ b/src/app/lib/blog-markdown.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import {
+  markdownToHtml,
+  normalizeAuthor,
+  slugify,
+  uniqueSlug,
+} from "./blog-markdown";
+
+describe("markdownToHtml", () => {
+  test("preserves markdown headings and strips script elements", async () => {
+    const html = await markdownToHtml(
+      "# Title\n\n<script>alert(1)</script>\n\nBody"
+    );
+
+    expect(html).toContain("<h1");
+    expect(html).toContain("Title");
+    expect(html).toContain("Body");
+    expect(html).not.toContain("<script");
+    expect(html).not.toContain("alert(1)");
+  });
+});
+
+describe("slugify", () => {
+  test("preserves unicode letters and falls back for symbols", () => {
+    expect(slugify("你好")).toBe("你好");
+    expect(slugify("!!!")).toBe("section");
+  });
+});
+
+describe("uniqueSlug", () => {
+  test("suffixes repeated headings", () => {
+    const used = new Set<string>();
+    expect(uniqueSlug("Usage", used)).toBe("usage");
+    expect(uniqueSlug("Usage", used)).toBe("usage-2");
+  });
+});
+
+describe("normalizeAuthor", () => {
+  test("accepts a scalar name or object", () => {
+    expect(normalizeAuthor("Tyler Witlin")).toEqual({ name: "Tyler Witlin" });
+    expect(normalizeAuthor({ name: "Tyler", avatar: "/a.jpg" })).toEqual({
+      name: "Tyler",
+      avatar: "/a.jpg",
+    });
+  });
+});

--- a/src/app/lib/blog-markdown.ts
+++ b/src/app/lib/blog-markdown.ts
@@ -1,0 +1,62 @@
+import { remark } from "remark";
+import remarkRehype from "remark-rehype";
+import rehypeSanitize from "rehype-sanitize";
+import rehypeSlug from "rehype-slug";
+import rehypeStringify from "rehype-stringify";
+import { BlogPost, BlogPostFrontMatter } from "../types/blog";
+
+export function stripHtmlTags(text: string): string {
+  let previous: string;
+  do {
+    previous = text;
+    text = text.replace(/<[^>]*>/g, "");
+  } while (text !== previous);
+  return text;
+}
+
+/** Slugifies a string for use as an HTML id attribute. */
+export function slugify(text: string): string {
+  const slug = stripHtmlTags(text)
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/\p{M}+/gu, "")
+    .replace(/[^\p{L}\p{N}]+/gu, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "section";
+}
+
+export function uniqueSlug(text: string, used: Set<string>): string {
+  const base = slugify(text);
+  let id = base;
+  let n = 2;
+  while (used.has(id)) {
+    id = `${base}-${n}`;
+    n += 1;
+  }
+  used.add(id);
+  return id;
+}
+
+type FrontMatterAuthor = BlogPostFrontMatter["author"] | string | undefined;
+
+export function normalizeAuthor(author: FrontMatterAuthor): BlogPost["author"] {
+  if (!author) {
+    return undefined;
+  }
+  if (typeof author === "string") {
+    const name = author.trim();
+    return name ? { name } : undefined;
+  }
+  const name = author.name?.trim();
+  return name ? { name, avatar: author.avatar } : undefined;
+}
+
+export async function markdownToHtml(markdown: string): Promise<string> {
+  const processed = await remark()
+    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(rehypeSanitize)
+    .use(rehypeSlug)
+    .use(rehypeStringify)
+    .process(markdown);
+  return String(processed);
+}

--- a/src/app/lib/blog-markdown.ts
+++ b/src/app/lib/blog-markdown.ts
@@ -1,9 +1,50 @@
 import { remark } from "remark";
 import remarkRehype from "remark-rehype";
+import rehypeHighlight from "rehype-highlight";
 import rehypeSanitize from "rehype-sanitize";
-import rehypeSlug from "rehype-slug";
 import rehypeStringify from "rehype-stringify";
 import { BlogPost, BlogPostFrontMatter } from "../types/blog";
+
+export type HastNode = {
+  type: string;
+  tagName?: string;
+  properties?: Record<string, unknown>;
+  children?: HastNode[];
+  value?: string;
+};
+
+function headingText(node: HastNode): string {
+  if (node.type === "text") {
+    return node.value ?? "";
+  }
+  return (node.children ?? []).map(headingText).join("");
+}
+
+export function applyHeadingIds(tree: HastNode) {
+  const used = new Set<string>();
+  walkHeadings(tree, used);
+}
+
+function assignHeadingIds() {
+  return (tree: HastNode) => {
+    applyHeadingIds(tree);
+  };
+}
+
+function walkHeadings(node: HastNode, used: Set<string>) {
+  if (node.type === "element" && node.tagName && /^h[1-6]$/.test(node.tagName)) {
+    const props = (node.properties ??= {});
+    const existing = typeof props.id === "string" ? props.id.trim() : "";
+    if (existing) {
+      used.add(existing);
+    } else {
+      props.id = uniqueSlug(headingText(node), used);
+    }
+  }
+  for (const child of node.children ?? []) {
+    walkHeadings(child, used);
+  }
+}
 
 export function stripHtmlTags(text: string): string {
   let previous: string;
@@ -55,7 +96,8 @@ export async function markdownToHtml(markdown: string): Promise<string> {
   const processed = await remark()
     .use(remarkRehype, { allowDangerousHtml: true })
     .use(rehypeSanitize)
-    .use(rehypeSlug)
+    .use(rehypeHighlight)
+    .use(assignHeadingIds)
     .use(rehypeStringify)
     .process(markdown);
   return String(processed);

--- a/src/app/lib/fs-blog.ts
+++ b/src/app/lib/fs-blog.ts
@@ -14,7 +14,17 @@ import {
 } from "./blog-path";
 import { remark } from "remark";
 import html from "remark-html";
+import sanitize from "rehype-sanitize";
 import { BlogPost, BlogPostFrontMatter, Heading } from "../types/blog";
+
+/** Slugifies a string for use as an HTML id attribute. */
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/<[^>]*>/g, "") // Remove HTML tags
+    .replace(/[\W_]+/g, "-") // Replace non-word chars and underscores with hyphens
+    .replace(/^-+|-+$/g, ""); // Trim leading/trailing hyphens
+}
 
 // Blog configuration
 const WORDS_PER_MINUTE = 200;
@@ -67,25 +77,24 @@ export async function getPostBySlug(slug: string): Promise<BlogPost> {
     throw new Error(`Missing date in post: ${realSlug}`);
   }
 
-  // Convert markdown to HTML
-  const processedContent = await remark().use(html, { sanitize: false }).process(content);
+  // Convert markdown to HTML with sanitization
+  const processedContent = await remark()
+    .use(html)
+    .use(sanitize)
+    .process(content);
 
   let contentHtml = processedContent.toString();
 
   // Add language classes to code blocks for syntax highlighting
   contentHtml = contentHtml.replace(
-    /<pre><code class="language-([^"]+)">/g,
+    /<pre><code class="language-([^\"]+)">/g,
     '<pre class="language-$1"><code class="language-$1">'
   );
 
   // Add IDs to headings for table of contents linking
-  contentHtml = contentHtml.replace(/<h([2-3])>(.*?)<\/h\1>/g, (match, level, content) => {
-    const id = content
-      .toLowerCase()
-      .replace(/<[^>]*>/g, "") // Remove HTML tags
-      .replace(/[^\w\s-]/g, "") // Remove special chars
-      .replace(/\s+/g, "-"); // Replace spaces with hyphens
-    return `<h${level} id="${id}">${content}</h${level}>`;
+  contentHtml = contentHtml.replace(/<h([2-3])>(.*?)<\/h\1>/gs, (match, level, headingContent) => {
+    const id = slugify(headingContent);
+    return `<h${level} id="${id}">${headingContent}</h${level}>`;
   });
 
   // Calculate reading time
@@ -109,6 +118,8 @@ export async function getPostBySlug(slug: string): Promise<BlogPost> {
     readingTime,
     tags: frontMatter.tags || [],
     coverImage: frontMatter.coverImage,
+    featured: frontMatter.featured,
+    author: frontMatter.author,
     headings,
   };
 
@@ -253,27 +264,19 @@ export async function getRelatedPosts(
  */
 export function extractHeadingsFromContent(content: string): Heading[] {
   // Match h2 and h3 headings with IDs
-  const headingRegex = /<h([2-3])(?:[^>]*id="([^"]+)"[^>]*)?>(.*?)<\/h\1>/g;
+  const headingRegex = /<h([2-3])(?:[^>]*id="([^"]+)"[^>]*)?>(.*?)<\/h\1>/gs;
   const headings: Heading[] = [];
   let match;
 
   while ((match = headingRegex.exec(content)) !== null) {
-    // If the heading doesn't have an ID, generate one from the content
     const level = parseInt(match[1]);
-    let text = match[3];
-    let previous;
-    do {
-      previous = text;
-      text = text.replace(/<[^>]*>/g, ""); // Strip HTML tags inside heading
-    } while (text !== previous);
+    // Strip HTML tags inside heading text
+    const text = match[3].replace(/<[^>]*>/g, "");
     let id = match[2];
 
     // If no ID found, generate one from the text content
     if (!id) {
-      id = text
-        .toLowerCase()
-        .replace(/[^\w\s-]/g, "") // Remove special chars
-        .replace(/\s+/g, "-"); // Replace spaces with hyphens
+      id = slugify(text);
     }
 
     headings.push({

--- a/src/app/lib/fs-blog.ts
+++ b/src/app/lib/fs-blog.ts
@@ -12,19 +12,13 @@ import {
   POSTS_DIRECTORY,
   resolvePostFilePath,
 } from "./blog-path";
-import { remark } from "remark";
-import html from "remark-html";
-import sanitize from "rehype-sanitize";
 import { BlogPost, BlogPostFrontMatter, Heading } from "../types/blog";
-
-/** Slugifies a string for use as an HTML id attribute. */
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/<[^>]*>/g, "") // Remove HTML tags
-    .replace(/[\W_]+/g, "-") // Replace non-word chars and underscores with hyphens
-    .replace(/^-+|-+$/g, ""); // Trim leading/trailing hyphens
-}
+import {
+  markdownToHtml,
+  normalizeAuthor,
+  stripHtmlTags,
+  uniqueSlug,
+} from "./blog-markdown";
 
 // Blog configuration
 const WORDS_PER_MINUTE = 200;
@@ -77,25 +71,12 @@ export async function getPostBySlug(slug: string): Promise<BlogPost> {
     throw new Error(`Missing date in post: ${realSlug}`);
   }
 
-  // Convert markdown to HTML with sanitization
-  const processedContent = await remark()
-    .use(html)
-    .use(sanitize)
-    .process(content);
+  let contentHtml = await markdownToHtml(content);
 
-  let contentHtml = processedContent.toString();
-
-  // Add language classes to code blocks for syntax highlighting
   contentHtml = contentHtml.replace(
     /<pre><code class="language-([^\"]+)">/g,
     '<pre class="language-$1"><code class="language-$1">'
   );
-
-  // Add IDs to headings for table of contents linking
-  contentHtml = contentHtml.replace(/<h([2-3])>(.*?)<\/h\1>/gs, (match, level, headingContent) => {
-    const id = slugify(headingContent);
-    return `<h${level} id="${id}">${headingContent}</h${level}>`;
-  });
 
   // Calculate reading time
   const wordCount = content.split(/\s+/g).length;
@@ -119,7 +100,7 @@ export async function getPostBySlug(slug: string): Promise<BlogPost> {
     tags: frontMatter.tags || [],
     coverImage: frontMatter.coverImage,
     featured: frontMatter.featured,
-    author: frontMatter.author,
+    author: normalizeAuthor(frontMatter.author),
     headings,
   };
 
@@ -266,17 +247,15 @@ export function extractHeadingsFromContent(content: string): Heading[] {
   // Match h2 and h3 headings with IDs
   const headingRegex = /<h([2-3])(?:[^>]*id="([^"]+)"[^>]*)?>(.*?)<\/h\1>/gs;
   const headings: Heading[] = [];
+  const usedIds = new Set<string>();
   let match;
 
   while ((match = headingRegex.exec(content)) !== null) {
-    const level = parseInt(match[1]);
-    // Strip HTML tags inside heading text
-    const text = match[3].replace(/<[^>]*>/g, "");
-    let id = match[2];
-
-    // If no ID found, generate one from the text content
-    if (!id) {
-      id = slugify(text);
+    const level = parseInt(match[1], 10);
+    const text = stripHtmlTags(match[3]);
+    const id = match[2] || uniqueSlug(text, usedIds);
+    if (match[2]) {
+      usedIds.add(match[2]);
     }
 
     headings.push({

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -11,7 +11,7 @@ export default function NotFound() {
   return (
     <Box
       sx={{
-        minHeight: { xs: "calc(100dvh - 180px)", md: "100vh" },
+        minHeight: { xs: "calc(100dvh - 180px)", md: "calc(100dvh - 72px)" },
         background: (theme) =>
           theme.palette.mode === "dark"
             ? `radial-gradient(circle at 25% 25%, ${theme.palette.background.paper} 0%, ${theme.palette.background.default} 100%)`

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -11,7 +11,7 @@ export default function NotFound() {
   return (
     <Box
       sx={{
-        minHeight: "calc(100vh - 180px)",
+        minHeight: { xs: "calc(100dvh - 180px)", md: "100vh" },
         background: (theme) =>
           theme.palette.mode === "dark"
             ? `radial-gradient(circle at 25% 25%, ${theme.palette.background.paper} 0%, ${theme.palette.background.default} 100%)`
@@ -25,7 +25,7 @@ export default function NotFound() {
       }}
     >
       {/* Animated background elements */}
-      {Array.from({ length: 15 }).map((_, i) => (
+      {Array.from({ length: 5 }).map((_, i) => (
         <Box
           component={motion.div}
           key={i}

--- a/src/app/types/blog.ts
+++ b/src/app/types/blog.ts
@@ -20,11 +20,13 @@ export interface BlogPostFrontMatter {
   /** Optional boolean to feature this post */
   featured?: boolean;
 
-  /** Optional author information */
-  author?: {
-    name: string;
-    avatar?: string;
-  };
+  /** Optional author name string or `{ name, avatar? }` object */
+  author?:
+    | string
+    | {
+        name: string;
+        avatar?: string;
+      };
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,7 @@
   "exclude": [
     "node_modules",
     "vite.config.ts",
-    "vitest-setup-client.ts"
+    "vitest-setup-client.ts",
+    "**/*.test.ts"
   ]
 }


### PR DESCRIPTION
Fixes from code review of witl-xyz:

**Security**
- Add `rehype-sanitize` to the markdown-to-HTML pipeline instead of using `sanitize: false`. This prevents XSS if any post contains malicious HTML/script.

**Correctness**
- Centralize heading ID generation via a single `slugify()` utility, used consistently in both heading rendering and table-of-contents extraction. Previously, two slightly different regex paths could produce inconsistent or colliding IDs.
- Propagate `featured` and `author` from frontmatter into `BlogPost` objects. These fields were defined in types but never populated, so functions like `getFeaturedPosts()` would always return empty.

**Readability & Architecture (Navbar refactor)**
- Extract Navbar logic into smaller units:
  - `useNavbarVisibility`: scroll-direction visibility logic
  - `useHash`: hash synchronization hook
  - `NAV_ITEMS`: typed nav array constant
  - `NavLink`, `ThemeToggleButton`, `MobileNavDrawer` as sub-components
- Fix React hooks rule violation where `useMediaQuery()` was incorrectly called inside JSX.
- Net ~130 LOC reduction; Navbar is easier to read and maintain.

**Performance**
- Reduce 404 animated background elements from 15 → 5 (less layout/paint churn).
- Use responsive `minHeight` instead of a brittle magic-value `calc(100vh - 180px)` on the 404 page.

**Documentation**
- Update README to document all supported frontmatter fields (`coverImage`, `featured`) and mark required vs optional.

Depends on adding `rehype-sanitize` to dependencies; run `bun install` after merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added flexible author details, featured posts, excerpts, and cover images.
  - Improved Markdown rendering with sanitized content, code highlighting, and reliable heading links.
  - Updated portfolio content to highlight microservices, cloud, and DevOps expertise.

- **Bug Fixes**
  - Improved responsive sizing on the not-found page.

- **Refactor**
  - Enhanced desktop and mobile navigation, including theme controls, drawer behavior, hash updates, and scroll handling.
  - Reduced animated background elements on the not-found page.

- **Documentation**
  - Expanded blog frontmatter documentation with required and optional fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds sanitized Markdown rendering and richer blog metadata, refactors the responsive navbar, updates portfolio content, and simplifies the not-found page.
- Adds `rehype-sanitize` with a corresponding Bun lockfile resolution.
- Centralizes heading slug generation and author normalization.
- Splits navbar behavior into hooks and smaller components.
- Documents supported blog frontmatter fields.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains in the previously reported Navbar or lockfile fixes.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/components/Navbar.tsx | Refactors navigation into focused hooks and components while resolving the previously reported mobile navigation and style-typing issues. |
| package.json | Adds `rehype-sanitize` to production dependencies. |
| bun.lock | Adds the matching `rehype-sanitize@6.0.0` resolution and preserves the transitive dependency closure required by frozen installs. |
| src/app/lib/blog-markdown.ts | Introduces sanitized Markdown conversion, deterministic heading IDs, and frontmatter author normalization. |
| src/app/lib/fs-blog.ts | Adopts the shared Markdown utilities and propagates featured and author metadata into blog posts. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Greploop%20coolguy1771%2Fwitl-xyz%20PR%20%23569%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&pr=569&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (5): Last reviewed commit: ["Apply remaining changes"](https://github.com/coolguy1771/witl-xyz/commit/7eabdb615dd95c3cddd9332f02e3833a476d5a2f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50614819)</sub>

<!-- /greptile_comment -->