### PR TITLE
feat(blog): add client-side tag filtering with URL sync

### DIFF
--- a/src/app/blog/components/BlogView.tsx
+++ b/src/app/blog/components/BlogView.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { Container, Typography, Box, useTheme, useMediaQuery, alpha, Button, Tooltip } from "@mui/material";
 import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
 import { motion } from "framer-motion";
 import { Rss as RssIcon } from "lucide-react";
 import { PostGrid } from "./listing/PostGrid";
@@ -19,37 +20,64 @@ interface BlogViewProps {
 export function BlogView({ posts, initialSelectedTag, showRssLink = false }: BlogViewProps) {
   const theme = useTheme();
   const isSmallScreen = useMediaQuery(theme.breakpoints.down("sm"));
+  const router = useRouter();
+  const searchParams = useSearchParams();
 
+  // Derive selected tag from URL; fall back to server-provided initialSelectedTag on mount
+  const urlTag = searchParams.get("tag") || "";
   const [selectedTags, setSelectedTags] = useState<string[]>(
-    initialSelectedTag ? [initialSelectedTag] : []
+    () => (initialSelectedTag ? [initialSelectedTag] : [])
   );
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
-  const [filteredPosts, setFilteredPosts] = useState<BlogPost[]>(posts);
 
-  // Handle tag selection/deselection
-  const handleTagToggle = (tag: string) => {
-    if (tag === "all") {
-      setSelectedTags([]);
-      return;
-    }
+  // Keep local state synced with URL changes (e.g. direct navigation to ?tag=X)
+  useEffect(() => {
+    setSelectedTags(urlTag ? [urlTag] : []);
+  }, [urlTag]);
 
-    if (selectedTags.includes(tag)) {
-      setSelectedTags(selectedTags.filter((t) => t !== tag));
-    } else {
-      setSelectedTags([...selectedTags, tag]);
-    }
-  };
+  const updateUrlTag = useCallback(
+    (tag: string | null) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (tag) {
+        params.set("tag", tag);
+      } else {
+        params.delete("tag");
+      }
+      const query = params.toString();
+      router.replace(`/blog${query ? `?${query}` : ""}`, { scroll: false });
+    },
+    [router, searchParams]
+  );
+
+  // Handle tag selection/deselection — single tag mode via URL
+  const handleTagToggle = useCallback(
+    (tag: string) => {
+      if (!tag) return;
+
+      // Toggle: if already selected, clear it
+      if (selectedTags.includes(tag)) {
+        setSelectedTags([]);
+        updateUrlTag(null);
+      } else {
+        // Select new tag — only one at a time via URL
+        setSelectedTags([tag]);
+        updateUrlTag(tag);
+      }
+    },
+    [selectedTags, updateUrlTag]
+  );
+
+  // Clear filter / go back to all posts
+  const handleClearFilter = useCallback(() => {
+    setSelectedTags([]);
+    updateUrlTag(null);
+  }, [updateUrlTag]);
 
   // Filter posts when selected tags change
-  useEffect(() => {
-    if (selectedTags.length === 0) {
-      setFilteredPosts(posts);
-    } else {
-      setFilteredPosts(
-        posts.filter((post) => post.tags?.some((tag) => selectedTags.includes(tag)))
-      );
-    }
-  }, [selectedTags, posts]);
+  const filteredPosts = React.useMemo(() => {
+    if (selectedTags.length === 0) return posts;
+    return posts.filter((post) => post.tags?.some((tag) => selectedTags.includes(tag)));
+  }, [posts, selectedTags]);
 
   return (
     <Box
@@ -164,8 +192,10 @@ export function BlogView({ posts, initialSelectedTag, showRssLink = false }: Blo
           }}
         >
           <PostFilterBar
+            posts={posts}
             selectedTags={selectedTags}
             onTagToggle={handleTagToggle}
+            onClearFilter={handleClearFilter}
             onViewChange={setViewMode}
             currentView={viewMode}
           />

--- a/src/app/blog/components/listing/PostFilterBar.tsx
+++ b/src/app/blog/components/listing/PostFilterBar.tsx
@@ -1,26 +1,48 @@
 "use client";
 
-import React from "react";
-import { Box, Chip, Typography, IconButton, useTheme, Skeleton } from "@mui/material";
-import { useBlogTags } from "../../hooks";
+import React, { useMemo } from "react";
+import { Box, Chip, Typography, IconButton, useTheme } from "@mui/material";
 import GridViewIcon from "@mui/icons-material/GridView";
 import ViewListIcon from "@mui/icons-material/ViewList";
+import { BlogPost } from "@/app/types/blog";
 
 interface PostFilterBarProps {
+  posts: BlogPost[];
   selectedTags: string[];
   onTagToggle: (tag: string) => void;
+  onClearFilter?: () => void;
   onViewChange: (view: "grid" | "list") => void;
   currentView: "grid" | "list";
 }
 
 export function PostFilterBar({
+  posts,
   selectedTags,
   onTagToggle,
+  onClearFilter,
   onViewChange,
   currentView,
 }: PostFilterBarProps) {
   const theme = useTheme();
-  const { tags, isLoading } = useBlogTags();
+
+  // Derive tags with counts from loaded posts (no API call needed)
+  const tagCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const post of posts) {
+      for (const tag of post.tags ?? []) {
+        counts.set(tag, (counts.get(tag) || 0) + 1);
+      }
+    }
+    return [...counts.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([tag, count]) => ({ tag, count }));
+  }, [posts]);
+
+  // Show number of filtered results when active filter exists
+  const visibleCount = useMemo(() => {
+    if (selectedTags.length === 0) return posts.length;
+    return posts.filter((p) => p.tags?.some((t) => selectedTags.includes(t))).length;
+  }, [posts, selectedTags]);
 
   return (
     <Box
@@ -47,58 +69,59 @@ export function PostFilterBar({
         </Typography>
 
         <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
-          {isLoading ? (
-            Array.from({ length: 5 }).map((_, i) => (
-              <Skeleton key={i} variant="rounded" width={80} height={32} />
-            ))
-          ) : (
-            <>
-              <Chip
-                label="All Posts"
-                onClick={() => selectedTags.forEach((tag) => onTagToggle(tag))}
-                color={selectedTags.length === 0 ? "primary" : "default"}
-                sx={{
-                  backgroundColor:
-                    selectedTags.length === 0
-                      ? theme.palette.primary.main
-                      : theme.palette.action.selected,
-                  color:
-                    selectedTags.length === 0
-                      ? theme.palette.primary.contrastText
-                      : theme.palette.text.primary,
-                  "&:hover": {
-                    backgroundColor:
-                      selectedTags.length === 0
-                        ? theme.palette.primary.dark
-                        : theme.palette.action.hover,
-                  },
-                }}
-              />
+          <Chip
+            label={selectedTags.length === 0 ? `All Posts` : `${posts.length} posts`}
+            onClick={() => onClearFilter?.()}
+            color={selectedTags.length === 0 ? "primary" : "default"}
+            sx={{
+              backgroundColor:
+                selectedTags.length === 0
+                  ? theme.palette.primary.main
+                  : theme.palette.action.selected,
+              color:
+                selectedTags.length === 0
+                  ? theme.palette.primary.contrastText
+                  : theme.palette.text.primary,
+              "&:hover": {
+                backgroundColor:
+                  selectedTags.length === 0
+                    ? theme.palette.primary.dark
+                    : theme.palette.action.hover,
+              },
+            }}
+          />
 
-              {tags.map((tag) => (
-                <Chip
-                  key={tag}
-                  label={tag}
-                  onClick={() => onTagToggle(tag)}
-                  color={selectedTags.includes(tag) ? "primary" : "default"}
-                  sx={{
-                    backgroundColor: selectedTags.includes(tag)
-                      ? theme.palette.primary.main
-                      : theme.palette.action.selected,
-                    color: selectedTags.includes(tag)
-                      ? theme.palette.primary.contrastText
-                      : theme.palette.text.primary,
-                    "&:hover": {
-                      backgroundColor: selectedTags.includes(tag)
-                        ? theme.palette.primary.dark
-                        : theme.palette.action.hover,
-                    },
-                  }}
-                />
-              ))}
-            </>
-          )}
+          {tagCounts.map(({ tag, count }) => (
+            <Chip
+              key={tag}
+              label={`${tag} (${count})`}
+              onClick={() => onTagToggle(tag)}
+              color={selectedTags.includes(tag) ? "primary" : "default"}
+              sx={{
+                backgroundColor: selectedTags.includes(tag)
+                  ? theme.palette.primary.main
+                  : theme.palette.action.selected,
+                color: selectedTags.includes(tag)
+                  ? theme.palette.primary.contrastText
+                  : theme.palette.text.primary,
+                "&:hover": {
+                  backgroundColor: selectedTags.includes(tag)
+                    ? theme.palette.primary.dark
+                    : theme.palette.action.hover,
+                },
+              }}
+            />
+          ))}
         </Box>
+
+        {selectedTags.length > 0 && (
+          <Typography
+            variant="caption"
+            sx={{ mt: 1, color: theme.palette.text.secondary }}
+          >
+            Showing {visibleCount} of {posts.length} posts tagged "{selectedTags.join(", ")}"
+          </Typography>
+        )}
       </Box>
 
       <Box sx={{ display: "flex", gap: 1, alignSelf: { xs: "flex-end", md: "auto" } }}>


### PR DESCRIPTION
## Summary

Adds client-side tag filtering on the blog listing page (/blog) using existing loaded post data.

## Changes

- Tag chips derived from already-loaded posts (no extra API call / no loading skeleton)
- Each tag chip shows post count, e.g. `kubernetes (5)`
- Clicking a tag filters posts client-side and updates URL to `?tag=kubernetes`
- Clicking the same tag again clears the filter
- Active tag highlighted; 'All Posts' chip resets to show all
- Filtered results summary shown below chips when a tag is active
- Tag state persists across page reloads via URL search params

## Tech notes

Uses `useRouter` + `useSearchParams` in `BlogView` to keep component state in sync with `?tag=`. Filtering runs via `useMemo` on the full posts array passed from the server-side page.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds client-side tag filtering to the blog listing and synchronizes the selected tag with the URL.
- Derives tag chips and post counts from the loaded posts.
- Filters the listing without another API request.
- Adds active-filter status text and view controls.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with only a non-blocking filter-reset discoverability concern remaining.

The previously reported reset-label concern remains, but no blocking failure remains.

**Files Needing Attention:** src/app/blog/components/listing/PostFilterBar.tsx
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/blog/components/BlogView.tsx | Synchronizes single-tag filter state with the URL and derives filtered posts from the supplied post collection. |
| src/app/blog/components/listing/PostFilterBar.tsx | Derives tag counts and visible-result totals from loaded posts and renders the filtering controls. |

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(blog): add client-side tag filterin..."](https://github.com/coolguy1771/witl-xyz/commit/d621b9030de00058c986dd2518d16cabb0dc44b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50638026)</sub>

<!-- /greptile_comment -->