### PR TITLE
feat: add Open Graph images for site and blog posts

### DIFF
--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,55 @@
+import { ImageResponse } from "next/og";
+import path from "path";
+import fs from "fs/promises";
+
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = "image/png";
+
+export default async function DefaultOpenGraphImage() {
+  const fontPath = path.join(process.cwd(), "src", "app", "fonts", "GeistMonoVF.woff");
+  const fontData = await fs.readFile(fontPath);
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          fontSize: 56,
+          fontWeight: 700,
+          color: "#ffffff",
+          background: "#0a0e14",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          alignItems: "center",
+          fontFamily: "'Geist Mono', monospace",
+        }}
+      >
+        <div style={{ textAlign: "center" }}>
+          <div style={{ fontSize: 72, marginBottom: 16, color: "#00d4ff" }}>
+            witl@xyz:~$ whoami
+          </div>
+          <div style={{ fontSize: 48, color: "#94a3b8" }}>Tyler Witlin</div>
+          <div style={{ fontSize: 28, marginTop: 16, color: "#3dd68c" }}>
+            DevOps Engineer @ Cisco Systems
+          </div>
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+      fonts: [
+        {
+          name: "Geist Mono",
+          data: fontData,
+          weight: 700,
+        },
+      ],
+    }
+  );
+}


### PR DESCRIPTION
- Add `/opengraph-image` route generating branded terminal-style OG card (witl@xyz:~$ whoami)
- Update root layout metadata with full openGraph config (url, type, siteName, image URL)
- Per-post metadata uses custom OG URL with encoded title+excerpt params
- Improved article-type OG fields (publishedTime, authors, section, updatedTime)
- Renamed 'My Blog' references to 'Tyler Witlin' in blog post metadata

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a Next.js Open Graph image route that renders a branded, terminal-style social card.
- Defines a 1200×630 PNG response.
- Loads the Geist Mono font for the generated image.
- Displays the site owner’s name, role, and terminal-inspired branding.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge based on the follow-up review scope.

No blocking failure remains within the eligible prior-thread scope.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/opengraph-image.tsx | Adds the branded default Open Graph image renderer; no follow-up-eligible issue was identified. |

</details>

<sub>Reviews (2): Last reviewed commit: ["feat: add Open Graph images for site and..."](https://github.com/coolguy1771/witl-xyz/commit/91d0618ab09fa65de60729fdf9fcd2c05d965d14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50651850)</sub>

<!-- /greptile_comment -->