### PR TITLE
feat(blog): add client-side search + project detail pages

### DIFF
--- a/src/app/api/blog/posts/route.ts
+++ b/src/app/api/blog/posts/route.ts
@@ -34,7 +34,11 @@ export async function GET(request: NextRequest) {
       posts = posts.slice(0, limit);
     }
 
-    return NextResponse.json(posts);
+    return NextResponse.json(posts, {
+      headers: {
+        "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=600",
+      },
+    });
   } catch (error) {
     console.error("Error in /api/blog/posts:", error);
     return NextResponse.json({ error: "Failed to fetch blog posts" }, { status: 500 });

--- a/src/app/api/github/[slug]/route.ts
+++ b/src/app/api/github/[slug]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { fetchGithubProjectBySlug } from "@/app/lib/github";
+
+export const revalidate = 3600;
+
+export async function GET(
+  request: NextRequest,
+  props: { params: Promise<{ slug: string }> }
+) {
+  try {
+    const params = await props.params;
+    const slug = params?.slug;
+
+    if (!slug) {
+      return NextResponse.json({ error: "Missing slug" }, { status: 400 });
+    }
+
+    const project = await fetchGithubProjectBySlug(slug);
+
+    if (!project) {
+      return NextResponse.json({ error: "Project not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(project, {
+      headers: {
+        "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=600",
+      },
+    });
+  } catch (error) {
+    console.error("Error in /api/github/[slug]:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/github/[slug]/route.ts
+++ b/src/app/api/github/[slug]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { fetchGithubProjectBySlug } from "@/app/lib/github";
+import { fetchGithubProjectBySlug, isValidRepoSlug } from "@/app/lib/github";
 
 export const revalidate = 3600;
 
@@ -13,6 +13,10 @@ export async function GET(
 
     if (!slug) {
       return NextResponse.json({ error: "Missing slug" }, { status: 400 });
+    }
+
+    if (!isValidRepoSlug(slug)) {
+      return NextResponse.json({ error: "Invalid slug" }, { status: 400 });
     }
 
     const project = await fetchGithubProjectBySlug(slug);

--- a/src/app/blog/components/BlogView.tsx
+++ b/src/app/blog/components/BlogView.tsx
@@ -31,8 +31,9 @@ interface BlogViewProps {
 /** Simple fuzzy matcher: each term must appear somewhere (case-insensitive). */
 function matchesSearch(text: string, query: string): boolean {
   if (!query || !query.trim()) return true;
+  const haystack = text.toLowerCase();
   const terms = query.toLowerCase().trim().split(/\s+/);
-  return terms.every((term) => text.includes(term));
+  return terms.every((term) => haystack.includes(term));
 }
 
 export function BlogView({ posts, initialSelectedTag, showRssLink = false }: BlogViewProps) {

--- a/src/app/blog/components/BlogView.tsx
+++ b/src/app/blog/components/BlogView.tsx
@@ -242,19 +242,21 @@ export function BlogView({ posts, initialSelectedTag, showRssLink = false }: Blo
               onChange={(e) => setSearchQuery(e.target.value)}
               size="small"
               variant="outlined"
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <SearchIcon size={16} color="#94a3b8" />
-                  </InputAdornment>
-                ),
-                endAdornment: searchQuery && (
-                  <InputAdornment position="end">
-                    <Button onClick={() => setSearchQuery("")} sx={{ minWidth: 24, p: 0.5 }} size="small">
-                      <XIcon size={16} color="#94a3b8" />
-                    </Button>
-                  </InputAdornment>
-                ),
+              slotProps={{
+                input: {
+                  startAdornment: (
+                    <InputAdornment position="start">
+                      <SearchIcon size={16} color="#94a3b8" />
+                    </InputAdornment>
+                  ),
+                  endAdornment: searchQuery ? (
+                    <InputAdornment position="end">
+                      <Button onClick={() => setSearchQuery("")} sx={{ minWidth: 24, p: 0.5 }} size="small">
+                        <XIcon size={16} color="#94a3b8" />
+                      </Button>
+                    </InputAdornment>
+                  ) : undefined,
+                },
               }}
               sx={{ "& .MuiOutlinedInput-root": { fontFamily: "'Geist Mono', monospace", fontSize: "0.85rem" } }}
             />

--- a/src/app/blog/components/BlogView.tsx
+++ b/src/app/blog/components/BlogView.tsx
@@ -1,11 +1,22 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from "react";
-import { Container, Typography, Box, useTheme, useMediaQuery, alpha, Button, Tooltip } from "@mui/material";
+import {
+  Container,
+  Typography,
+  Box,
+  useTheme,
+  useMediaQuery,
+  alpha,
+  Button,
+  Tooltip,
+  TextField,
+  InputAdornment,
+} from "@mui/material";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { motion } from "framer-motion";
-import { Rss as RssIcon } from "lucide-react";
+import { Rss as RssIcon, Search as SearchIcon, X as XIcon } from "lucide-react";
 import { PostGrid } from "./listing/PostGrid";
 import { PostList } from "./listing/PostList";
 import { PostFilterBar } from "./listing/PostFilterBar";
@@ -15,6 +26,13 @@ interface BlogViewProps {
   posts: BlogPost[];
   initialSelectedTag?: string;
   showRssLink?: boolean;
+}
+
+/** Simple fuzzy matcher: each term must appear somewhere (case-insensitive). */
+function matchesSearch(text: string, query: string): boolean {
+  if (!query || !query.trim()) return true;
+  const terms = query.toLowerCase().trim().split(/\s+/);
+  return terms.every((term) => text.includes(term));
 }
 
 export function BlogView({ posts, initialSelectedTag, showRssLink = false }: BlogViewProps) {
@@ -29,6 +47,7 @@ export function BlogView({ posts, initialSelectedTag, showRssLink = false }: Blo
     () => (initialSelectedTag ? [initialSelectedTag] : [])
   );
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
+  const [searchQuery, setSearchQuery] = useState("");
 
   // Keep local state synced with URL changes (e.g. direct navigation to ?tag=X)
   useEffect(() => {
@@ -67,17 +86,39 @@ export function BlogView({ posts, initialSelectedTag, showRssLink = false }: Blo
     [selectedTags, updateUrlTag]
   );
 
-  // Clear filter / go back to all posts
   const handleClearFilter = useCallback(() => {
     setSelectedTags([]);
     updateUrlTag(null);
   }, [updateUrlTag]);
 
-  // Filter posts when selected tags change
+  const handleClearAll = useCallback(() => {
+    setSelectedTags([]);
+    setSearchQuery("");
+    updateUrlTag(null);
+  }, [updateUrlTag]);
+
   const filteredPosts = React.useMemo(() => {
-    if (selectedTags.length === 0) return posts;
-    return posts.filter((post) => post.tags?.some((tag) => selectedTags.includes(tag)));
-  }, [posts, selectedTags]);
+    let result = posts;
+    if (selectedTags.length > 0) {
+      result = result.filter((post) =>
+        post.tags?.some((tag) => selectedTags.includes(tag)),
+      );
+    }
+    if (searchQuery.trim()) {
+      result = result.filter((post) => {
+        const searchable = [
+          post.title || "",
+          post.excerpt || "",
+          ...(post.tags || []),
+          (post.content || "").replace(/<[^>]+>/g, " "),
+        ]
+          .join(" ")
+          .toLowerCase();
+        return matchesSearch(searchable, searchQuery);
+      });
+    }
+    return result;
+  }, [posts, selectedTags, searchQuery]);
 
   return (
     <Box
@@ -191,6 +232,48 @@ export function BlogView({ posts, initialSelectedTag, showRssLink = false }: Blo
             backdropFilter: "blur(8px)",
           }}
         >
+          {/* Search input */}
+          <Box sx={{ display: "flex", gap: 2, mb: 3, alignItems: "center" }}>
+            <TextField
+              fullWidth
+              placeholder="Search posts..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              size="small"
+              variant="outlined"
+              InputProps={{
+                startAdornment: (
+                  <InputAdornment position="start">
+                    <SearchIcon size={16} color="#94a3b8" />
+                  </InputAdornment>
+                ),
+                endAdornment: searchQuery && (
+                  <InputAdornment position="end">
+                    <Button onClick={() => setSearchQuery("")} sx={{ minWidth: 24, p: 0.5 }} size="small">
+                      <XIcon size={16} color="#94a3b8" />
+                    </Button>
+                  </InputAdornment>
+                ),
+              }}
+              sx={{ "& .MuiOutlinedInput-root": { fontFamily: "'Geist Mono', monospace", fontSize: "0.85rem" } }}
+            />
+
+            {(selectedTags.length > 0 || searchQuery.trim()) && (
+              <Button onClick={handleClearAll} size="small" variant="outlined" sx={{ fontFamily: "'Geist Mono', monospace", borderRadius: "999px", px: 2 }}>
+                Clear all
+              </Button>
+            )}
+          </Box>
+
+          {/* Results count */}
+          {(searchQuery.trim() || selectedTags.length > 0) && (
+            <Typography variant="caption" sx={{ fontFamily: "'Geist Mono', monospace", color: theme.palette.text.secondary, mb: 2, display: "block" }}>
+              Showing {filteredPosts.length} of {posts.length} posts
+              {searchQuery.trim() && ` matching "${searchQuery}"`}
+              {selectedTags.length > 0 && ` with tags ${selectedTags.map((t) => `'${t}'`).join(", ")}`}
+            </Typography>
+          )}
+
           <PostFilterBar
             posts={posts}
             selectedTags={selectedTags}

--- a/src/app/blog/components/BlogView.tsx
+++ b/src/app/blog/components/BlogView.tsx
@@ -21,6 +21,7 @@ import { PostGrid } from "./listing/PostGrid";
 import { PostList } from "./listing/PostList";
 import { PostFilterBar } from "./listing/PostFilterBar";
 import { BlogPost } from "@/app/types/blog";
+import { CODE_FONT_FAMILY } from "@/app/lib/code-font";
 
 interface BlogViewProps {
   posts: BlogPost[];
@@ -28,12 +29,9 @@ interface BlogViewProps {
   showRssLink?: boolean;
 }
 
-/** Simple fuzzy matcher: each term must appear somewhere (case-insensitive). */
-function matchesSearch(text: string, query: string): boolean {
-  if (!query || !query.trim()) return true;
-  const haystack = text.toLowerCase();
-  const terms = query.toLowerCase().trim().split(/\s+/);
-  return terms.every((term) => haystack.includes(term));
+/** Each whitespace-separated term must appear in already-normalized text. */
+function matchesSearch(text: string, terms: string[]): boolean {
+  return terms.every((term) => text.includes(term));
 }
 
 export function BlogView({ posts, initialSelectedTag, showRssLink = false }: BlogViewProps) {
@@ -98,28 +96,35 @@ export function BlogView({ posts, initialSelectedTag, showRssLink = false }: Blo
     updateUrlTag(null);
   }, [updateUrlTag]);
 
-  const filteredPosts = React.useMemo(() => {
-    let result = posts;
-    if (selectedTags.length > 0) {
-      result = result.filter((post) =>
-        post.tags?.some((tag) => selectedTags.includes(tag)),
-      );
-    }
-    if (searchQuery.trim()) {
-      result = result.filter((post) => {
-        const searchable = [
+  const searchablePosts = React.useMemo(
+    () =>
+      posts.map((post) => ({
+        post,
+        text: [
           post.title || "",
           post.excerpt || "",
           ...(post.tags || []),
           (post.content || "").replace(/<[^>]+>/g, " "),
         ]
           .join(" ")
-          .toLowerCase();
-        return matchesSearch(searchable, searchQuery);
-      });
+          .toLowerCase(),
+      })),
+    [posts],
+  );
+
+  const filteredPosts = React.useMemo(() => {
+    let indexed = searchablePosts;
+    if (selectedTags.length > 0) {
+      indexed = indexed.filter(({ post }) =>
+        post.tags?.some((tag) => selectedTags.includes(tag)),
+      );
     }
-    return result;
-  }, [posts, selectedTags, searchQuery]);
+    if (searchQuery.trim()) {
+      const terms = searchQuery.toLowerCase().trim().split(/\s+/);
+      indexed = indexed.filter(({ text }) => matchesSearch(text, terms));
+    }
+    return indexed.map(({ post }) => post);
+  }, [searchablePosts, selectedTags, searchQuery]);
 
   return (
     <Box
@@ -243,6 +248,7 @@ export function BlogView({ posts, initialSelectedTag, showRssLink = false }: Blo
               size="small"
               variant="outlined"
               slotProps={{
+                htmlInput: { "aria-label": "Search posts" },
                 input: {
                   startAdornment: (
                     <InputAdornment position="start">
@@ -251,18 +257,23 @@ export function BlogView({ posts, initialSelectedTag, showRssLink = false }: Blo
                   ),
                   endAdornment: searchQuery ? (
                     <InputAdornment position="end">
-                      <Button onClick={() => setSearchQuery("")} sx={{ minWidth: 24, p: 0.5 }} size="small">
+                      <Button
+                        aria-label="Clear search"
+                        onClick={() => setSearchQuery("")}
+                        sx={{ minWidth: 24, p: 0.5 }}
+                        size="small"
+                      >
                         <XIcon size={16} color="#94a3b8" />
                       </Button>
                     </InputAdornment>
                   ) : undefined,
                 },
               }}
-              sx={{ "& .MuiOutlinedInput-root": { fontFamily: "'Geist Mono', monospace", fontSize: "0.85rem" } }}
+              sx={{ "& .MuiOutlinedInput-root": { fontFamily: CODE_FONT_FAMILY, fontSize: "0.85rem" } }}
             />
 
             {(selectedTags.length > 0 || searchQuery.trim()) && (
-              <Button onClick={handleClearAll} size="small" variant="outlined" sx={{ fontFamily: "'Geist Mono', monospace", borderRadius: "999px", px: 2 }}>
+              <Button onClick={handleClearAll} size="small" variant="outlined" sx={{ fontFamily: CODE_FONT_FAMILY, borderRadius: "999px", px: 2 }}>
                 Clear all
               </Button>
             )}
@@ -270,7 +281,7 @@ export function BlogView({ posts, initialSelectedTag, showRssLink = false }: Blo
 
           {/* Results count */}
           {(searchQuery.trim() || selectedTags.length > 0) && (
-            <Typography variant="caption" sx={{ fontFamily: "'Geist Mono', monospace", color: theme.palette.text.secondary, mb: 2, display: "block" }}>
+            <Typography variant="caption" sx={{ fontFamily: CODE_FONT_FAMILY, color: theme.palette.text.secondary, mb: 2, display: "block" }}>
               Showing {filteredPosts.length} of {posts.length} posts
               {searchQuery.trim() && ` matching "${searchQuery}"`}
               {selectedTags.length > 0 && ` with tags ${selectedTags.map((t) => `'${t}'`).join(", ")}`}

--- a/src/app/blog/components/listing/PostFilterBar.tsx
+++ b/src/app/blog/components/listing/PostFilterBar.tsx
@@ -38,12 +38,6 @@ export function PostFilterBar({
       .map(([tag, count]) => ({ tag, count }));
   }, [posts]);
 
-  // Show number of filtered results when active filter exists
-  const visibleCount = useMemo(() => {
-    if (selectedTags.length === 0) return posts.length;
-    return posts.filter((p) => p.tags?.some((t) => selectedTags.includes(t))).length;
-  }, [posts, selectedTags]);
-
   return (
     <Box
       sx={{
@@ -113,15 +107,6 @@ export function PostFilterBar({
             />
           ))}
         </Box>
-
-        {selectedTags.length > 0 && (
-          <Typography
-            variant="caption"
-            sx={{ mt: 1, color: theme.palette.text.secondary }}
-          >
-            Showing {visibleCount} of {posts.length} posts tagged "{selectedTags.join(", ")}"
-          </Typography>
-        )}
       </Box>
 
       <Box sx={{ display: "flex", gap: 1, alignSelf: { xs: "flex-end", md: "auto" } }}>

--- a/src/app/lib/github.ts
+++ b/src/app/lib/github.ts
@@ -1,7 +1,96 @@
 import "server-only";
 
 import { Octokit } from "@octokit/rest";
+import { remark } from "remark";
+import html from "remark-html";
 import { Project } from "../types";
+
+export const DEFAULT_GITHUB_OWNER = "coolguy1771";
+
+const REPO_SLUG = /^[A-Za-z0-9._-]+$/;
+
+export type GithubProjectDetail = {
+  name: string;
+  full_name: string;
+  description: string;
+  topics: string[];
+  language: string | null;
+  htmlUrl: string;
+  homepage: string | null;
+  stars: number;
+  forks: number;
+  openIssues: number;
+  license: string | null;
+  lastUpdated: string;
+  isFork: boolean;
+  isArchived: boolean;
+  readmeHtml: string;
+};
+
+type RepoPayload = {
+  name: string;
+  full_name: string;
+  description: string | null;
+  topics?: string[];
+  language: string | null;
+  html_url: string;
+  homepage: string | null;
+  stargazers_count?: number;
+  forks_count?: number;
+  open_issues_count?: number;
+  license: { spdx_id?: string | null; name?: string | null } | null;
+  updated_at: string | null;
+  fork: boolean;
+  archived: boolean;
+  private?: boolean;
+};
+
+function createOctokit() {
+  return new Octokit({ auth: process.env.GITHUB_TOKEN });
+}
+
+export function isValidRepoSlug(slug: string): boolean {
+  return REPO_SLUG.test(slug);
+}
+
+function mapRepoToDetail(
+  repo: RepoPayload,
+  readmeHtml: string,
+): GithubProjectDetail {
+  return {
+    name: repo.name,
+    full_name: repo.full_name,
+    description: repo.description || "No description available",
+    topics: repo.topics ?? [],
+    language: repo.language,
+    htmlUrl: repo.html_url,
+    homepage: repo.homepage,
+    stars: repo.stargazers_count ?? 0,
+    forks: repo.forks_count ?? 0,
+    openIssues: repo.open_issues_count ?? 0,
+    license: repo.license?.spdx_id || repo.license?.name || null,
+    lastUpdated: repo.updated_at ?? "",
+    isFork: repo.fork,
+    isArchived: repo.archived,
+    readmeHtml,
+  };
+}
+
+async function fetchSanitizedReadme(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+): Promise<string> {
+  try {
+    const { data } = await octokit.repos.getReadme({ owner, repo });
+    if (!("content" in data) || !data.content) return "";
+    const markdown = Buffer.from(data.content, "base64").toString("utf8");
+    const result = await remark().use(html).process(markdown);
+    return String(result);
+  } catch {
+    return "";
+  }
+}
 
 /**
  * Fetches public GitHub repositories for display. Server-only — use via /api/github/projects.
@@ -11,10 +100,7 @@ export async function fetchGithubProjects(
   limit: number = 6
 ): Promise<Project[]> {
   try {
-    const octokit = new Octokit({
-      auth: process.env.GITHUB_TOKEN,
-    });
-
+    const octokit = createOctokit();
     const response = await octokit.repos.listForUser({
       username,
       sort: "updated",
@@ -38,5 +124,22 @@ export async function fetchGithubProjects(
   } catch (error) {
     console.error("Error fetching GitHub projects:", error);
     return [];
+  }
+}
+
+export async function fetchGithubProjectBySlug(
+  slug: string,
+  owner: string = DEFAULT_GITHUB_OWNER,
+): Promise<GithubProjectDetail | null> {
+  if (!isValidRepoSlug(slug)) return null;
+  try {
+    const octokit = createOctokit();
+    const { data } = await octokit.repos.get({ owner, repo: slug });
+    if (data.private) return null;
+    const readmeHtml = await fetchSanitizedReadme(octokit, owner, slug);
+    return mapRepoToDetail(data, readmeHtml);
+  } catch (error) {
+    console.error("Error fetching GitHub project:", error);
+    return null;
   }
 }

--- a/src/app/lib/github.ts
+++ b/src/app/lib/github.ts
@@ -88,6 +88,9 @@ function rewriteRelativeUrls(
   const raw = `https://raw.githubusercontent.com/${owner}/${repo}/HEAD/`;
   return markup.replace(/\b(href|src)="([^"]*)"/gi, (match, attr, url) => {
     if (!url || ABSOLUTE_OR_HASH.test(url)) return match;
+    if (url.startsWith("/")) {
+      return `${attr}="https://github.com${url}"`;
+    }
     const cleaned = url.replace(/^\.\//, "");
     const base = String(attr).toLowerCase() === "src" ? raw : blob;
     return `${attr}="${base}${cleaned}"`;

--- a/src/app/lib/github.ts
+++ b/src/app/lib/github.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { cache } from "react";
 import { Octokit } from "@octokit/rest";
 import { remark } from "remark";
 import html from "remark-html";
@@ -53,6 +54,46 @@ export function isValidRepoSlug(slug: string): boolean {
   return REPO_SLUG.test(slug);
 }
 
+function isHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function safeHomepage(url: string | null): string | null {
+  if (!url) return null;
+  return isHttpUrl(url) ? url : null;
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    (error as { status: unknown }).status === 404
+  );
+}
+
+const ABSOLUTE_OR_HASH = /^(?:[a-z][a-z0-9+.-]*:|\/\/|#)/i;
+
+function rewriteRelativeUrls(
+  markup: string,
+  owner: string,
+  repo: string,
+): string {
+  const blob = `https://github.com/${owner}/${repo}/blob/HEAD/`;
+  const raw = `https://raw.githubusercontent.com/${owner}/${repo}/HEAD/`;
+  return markup.replace(/\b(href|src)="([^"]*)"/gi, (match, attr, url) => {
+    if (!url || ABSOLUTE_OR_HASH.test(url)) return match;
+    const cleaned = url.replace(/^\.\//, "");
+    const base = String(attr).toLowerCase() === "src" ? raw : blob;
+    return `${attr}="${base}${cleaned}"`;
+  });
+}
+
 function mapRepoToDetail(
   repo: RepoPayload,
   readmeHtml: string,
@@ -64,7 +105,7 @@ function mapRepoToDetail(
     topics: repo.topics ?? [],
     language: repo.language,
     htmlUrl: repo.html_url,
-    homepage: repo.homepage,
+    homepage: safeHomepage(repo.homepage),
     stars: repo.stargazers_count ?? 0,
     forks: repo.forks_count ?? 0,
     openIssues: repo.open_issues_count ?? 0,
@@ -86,7 +127,7 @@ async function fetchSanitizedReadme(
     if (!("content" in data) || !data.content) return "";
     const markdown = Buffer.from(data.content, "base64").toString("utf8");
     const result = await remark().use(html).process(markdown);
-    return String(result);
+    return rewriteRelativeUrls(String(result), owner, repo);
   } catch {
     return "";
   }
@@ -127,19 +168,22 @@ export async function fetchGithubProjects(
   }
 }
 
-export async function fetchGithubProjectBySlug(
-  slug: string,
-  owner: string = DEFAULT_GITHUB_OWNER,
-): Promise<GithubProjectDetail | null> {
-  if (!isValidRepoSlug(slug)) return null;
-  try {
-    const octokit = createOctokit();
-    const { data } = await octokit.repos.get({ owner, repo: slug });
-    if (data.private) return null;
-    const readmeHtml = await fetchSanitizedReadme(octokit, owner, slug);
-    return mapRepoToDetail(data, readmeHtml);
-  } catch (error) {
-    console.error("Error fetching GitHub project:", error);
-    return null;
-  }
-}
+export const fetchGithubProjectBySlug = cache(
+  async (
+    slug: string,
+    owner: string = DEFAULT_GITHUB_OWNER,
+  ): Promise<GithubProjectDetail | null> => {
+    if (!isValidRepoSlug(slug)) return null;
+    try {
+      const octokit = createOctokit();
+      const { data } = await octokit.repos.get({ owner, repo: slug });
+      if (data.private) return null;
+      const readmeHtml = await fetchSanitizedReadme(octokit, owner, slug);
+      return mapRepoToDetail(data, readmeHtml);
+    } catch (error) {
+      if (isNotFoundError(error)) return null;
+      console.error("Error fetching GitHub project:", error);
+      throw error;
+    }
+  },
+);

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -5,6 +5,7 @@ import {
   fetchGithubProjectBySlug,
   type GithubProjectDetail,
 } from "@/app/lib/github";
+import { CODE_FONT_FAMILY } from "@/app/lib/code-font";
 import { Box, Container, Typography, Button, Chip, Stack, Paper } from "@mui/material";
 import { Star, GitFork, Calendar, Code2, ExternalLink, ArrowLeft, Tag, Bug } from "lucide-react";
 import { FaGithub } from "react-icons/fa";
@@ -31,7 +32,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     if (!project) return {};
 
     const description =
-      `${project.description}` || `GitHub repository: ${project.full_name}`;
+      project.description?.trim() || `GitHub repository: ${project.full_name}`;
 
     return {
       title: `${project.name} - Tyler Witlin`,
@@ -126,7 +127,7 @@ export default async function ProjectDetailPage(props: Props) {
                 {project.name}
               </Typography>
 
-              <Typography variant="body2" color="text.secondary" sx={{ fontFamily: "'Geist Mono', monospace" }}>
+              <Typography variant="body2" color="text.secondary" sx={{ fontFamily: CODE_FONT_FAMILY }}>
                 {project.full_name}
               </Typography>
             </Box>
@@ -331,7 +332,7 @@ function ReadmeSection({
             mb: 1.5,
           },
           "& code": {
-            fontFamily: "'Fira Code', monospace",
+            fontFamily: CODE_FONT_FAMILY,
             backgroundColor: (t) => t.palette.mode === "dark" ? "#1e1e2e" : "#f0f0f0",
             padding: "0.15em 0.35em",
             borderRadius: "4px",

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,0 +1,356 @@
+import type { Metadata, ResolvingMetadata } from "next";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { fetchGithubProjectBySlug } from "@/app/lib/github";
+import { Box, Container, Typography, Button, Chip, Stack, Paper, useTheme } from "@mui/material";
+import { Star, GitFork, Calendar, Code2, ExternalLink, ArrowLeft, Tag, Bug } from "lucide-react";
+import { FaGithub } from "react-icons/fa";
+import { formatDistanceToNow } from "date-fns";
+
+type Props = {
+  params: Promise<{ slug: string }>;
+};
+
+export async function generateStaticParams() {
+  // Use dynamic for now to allow any valid slug without build-time pregeneration
+  return [];
+}
+
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata(
+  props: Props,
+  parent: ResolvingMetadata
+): Promise<Metadata> {
+  try {
+    const params = await props.params;
+    const slug = params?.slug;
+    if (!slug) return {};
+
+    const project = await fetchGithubProjectBySlug(slug);
+    if (!project) return {};
+
+    const description =
+      `${project.description}` || `GitHub repository: ${project.full_name}`;
+
+    return {
+      title: `${project.name} - Tyler Witlin`,
+      description,
+      keywords: [...project.topics, project.language].filter(Boolean),
+      openGraph: {
+        title: `${project.name} - Project Detail`,
+        description,
+        type: "website",
+        siteName: "Tyler Witlin",
+        url: `https://witl.xyz/projects/${slug}`,
+      },
+      twitter: {
+        card: "summary_large_image",
+        title: `${project.name} - Tyler Witlin`,
+        description,
+      },
+    };
+  } catch (error) {
+    console.error("Error generating metadata for project:", error);
+    return {};
+  }
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return String(n);
+}
+
+export default async function ProjectDetailPage(props: Props) {
+  const params = await props.params;
+  const slug = params?.slug;
+  if (!slug) notFound();
+
+  const project = await fetchGithubProjectBySlug(slug);
+  if (!project) notFound();
+
+  return (
+    <Box sx={{ minHeight: "calc(100vh - 180px)", py: { xs: 4, md: 8 } }}>
+      <Container maxWidth="lg">
+        {/* Breadcrumb / Back button */}
+        <Box sx={{ mb: 4 }}>
+          <Link href="/" style={{ textDecoration: "none" }}>
+            <Button
+              startIcon={<ArrowLeft size={16} />}
+              sx={{
+                color: (t) => t.palette.text.secondary,
+                textTransform: "none",
+                fontSize: "0.9rem",
+              }}
+            >
+              Back to Home
+            </Button>
+          </Link>
+        </Box>
+
+        {/* Header Card */}
+        <Paper
+          elevation={2}
+          sx={{
+            p: { xs: 3, md: 5 },
+            mb: 4,
+            borderRadius: 2,
+            border: (t) => `1px solid ${t.palette.divider}`,
+            position: "relative",
+            overflow: "hidden",
+            "&::before": {
+              content: '""',
+              position: "absolute",
+              top: 0,
+              left: 0,
+              right: 0,
+              height: "3px",
+              background: (t) => `linear-gradient(90deg, ${t.palette.primary.main}, ${t.palette.secondary.main})`,
+            },
+          }}
+        >
+          {/* Title row */}
+          <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 2, flexWrap: "wrap", mb: 2 }}>
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Typography
+                variant="h4"
+                component="h1"
+                sx={{
+                  fontWeight: 700,
+                  fontSize: { xs: "1.5rem", sm: "2rem" },
+                  mb: 1,
+                }}
+              >
+                {project.name}
+              </Typography>
+
+              <Typography variant="body2" color="text.secondary" sx={{ fontFamily: "'Geist Mono', monospace" }}>
+                {project.full_name}
+              </Typography>
+            </Box>
+
+            <Stack direction="row" spacing={1} flexShrink={0}>
+              <Button
+                component="a"
+                href={project.htmlUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                startIcon={<FaGithub size={18} />}
+                variant="outlined"
+                size="medium"
+                sx={{ borderRadius: 2 }}
+              >
+                View on GitHub
+              </Button>
+
+              {project.homepage && (
+                <Button
+                  component="a"
+                  href={project.homepage}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  startIcon={<ExternalLink size={18} />}
+                  variant="outlined"
+                  size="medium"
+                  sx={{ borderRadius: 2 }}
+                >
+                  Live Site
+                </Button>
+              )}
+            </Stack>
+          </Box>
+
+          {/* Description */}
+          <Typography
+            variant="body1"
+            color="text.secondary"
+            sx={{ mb: 3, lineHeight: 1.6 }}
+          >
+            {project.description}
+          </Typography>
+
+          {/* Stats row */}
+          <Stack
+            direction="row"
+            spacing={2}
+            flexWrap="wrap"
+            alignItems="center"
+            sx={{ mb: 3 }}
+          >
+            <StatPill icon={<Star size={14} />} label={`${formatNumber(project.stars)} stars`} />
+            <StatPill icon={<GitFork size={14} />} label={`${formatNumber(project.forks)} forks`} />
+            <StatPill icon={<Bug size={14} />} label={`${project.openIssues} open issues`} />
+
+            {project.language && (
+              <Chip
+                icon={<Code2 size={14} />}
+                label={project.language}
+                size="small"
+                sx={{
+                  backgroundColor: (t) => t.palette.primary.main + "15",
+                  color: (t) => t.palette.primary.main,
+                  border: `1px solid ${t.palette.primary.main}30`,
+                  height: 28,
+                }}
+              />
+            )}
+
+            {project.license && (
+              <Chip label={project.license} size="small" sx={{ height: 28, fontSize: "0.7rem" }} />
+            )}
+
+            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, color: "text.secondary", fontSize: "0.75rem" }}>
+              <Calendar size={14} />
+              Updated {formatDistanceToNow(new Date(project.lastUpdated), { addSuffix: true })}
+            </Box>
+          </Stack>
+
+          {/* Topics */}
+          {project.topics.length > 0 && (
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
+              <Tag size={14} color={(theme) => theme.palette.text.secondary as string} />
+              <Stack direction="row" spacing={0.5} flexWrap="wrap">
+                {project.topics.map((topic) => (
+                  <Chip
+                    key={topic}
+                    label={`#${topic}`}
+                    size="small"
+                    sx={{
+                      height: 24,
+                      fontSize: "0.7rem",
+                      backgroundColor: (t) => t.palette.secondary.main + "10",
+                      color: (t) => t.palette.secondary.main,
+                      border: `1px solid ${t.palette.secondary.main}30`,
+                    }}
+                  />
+                ))}
+              </Stack>
+            </Box>
+          )}
+
+          {/* Fork / Archived badges */}
+          <Box sx={{ mt: 2 }}>
+            {project.isFork && (
+              <Chip label="Fork" size="small" color="default" sx={{ mr: 1 }} />
+            )}
+            {project.isArchived && (
+              <Chip label="Archived" size="small" color="error" />
+            )}
+          </Box>
+        </Paper>
+
+        {/* README Section */}
+        {project.readmeHtml ? (
+          <ReadmeSection project={project} />
+        ) : (
+          <Paper
+            elevation={1}
+            sx={{
+              p: 4,
+              textAlign: "center",
+              borderRadius: 2,
+              border: (t) => `1px solid ${t.palette.divider}`,
+            }}
+          >
+            <Typography color="text.secondary">
+              No README available for this repository.
+            </Typography>
+          </Paper>
+        )}
+      </Container>
+    </Box>
+  );
+}
+
+function StatPill({ icon, label }: { icon: React.ReactNode; label: string }) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 0.5,
+        color: "text.secondary",
+        fontSize: "0.78rem",
+      }}
+    >
+      {icon}
+      {label}
+    </Box>
+  );
+}
+
+function ReadmeSection({ project }: { project: Awaited<ReturnType<typeof fetchGithubProjectBySlug>> & { readmeHtml: string } }) {
+  return (
+    <Paper
+      elevation={1}
+      sx={{
+        borderRadius: 2,
+        border: (t) => `1px solid ${t.palette.divider}`,
+        overflow: "hidden",
+      }}
+    >
+      {/* README header */}
+      <Box
+        sx={{
+          px: 3,
+          py: 2,
+          borderBottom: (t) => `1px solid ${t.palette.divider}`,
+          backgroundColor: (t) => t.palette.background.paper,
+          display: "flex",
+          alignItems: "center",
+          gap: 1,
+        }}
+      >
+        <Code2 size={16} color={(t) => t.palette.primary.main as string} />
+        <Typography variant="body2" fontWeight={600}>
+          README
+        </Typography>
+      </Box>
+
+      {/* Rendered markdown — styled to look like GitHub readme */}
+      <Box
+        sx={{
+          p: { xs: 2, md: 4 },
+          "& h1, & h2, & h3, & h4": {
+            fontWeight: 600,
+            mt: 3,
+            mb: 1.5,
+          },
+          "& code": {
+            fontFamily: "'Fira Code', monospace",
+            backgroundColor: (t) => t.palette.mode === "dark" ? "#1e1e2e" : "#f0f0f0",
+            padding: "0.15em 0.35em",
+            borderRadius: "4px",
+            fontSize: "0.875em",
+          },
+          "& pre": {
+            backgroundColor: (t) => t.palette.mode === "dark" ? "#0d1117" : "#f6f8fa",
+            padding: 2,
+            borderRadius: 8,
+            overflow: "auto",
+            marginBottom: 2,
+          },
+          "& pre code": {
+            backgroundColor: "transparent",
+            padding: 0,
+          },
+          "& a": {
+            color: (t) => t.palette.primary.main,
+          },
+          "& blockquote": {
+            borderLeft: (t) => `4px solid ${t.palette.divider}`,
+            paddingLeft: 2,
+            margin: "1em 0",
+            color: "text.secondary",
+          },
+          "& img": {
+            maxWidth: "100%",
+            height: "auto",
+            borderRadius: 8,
+          },
+        }}
+        dangerouslySetInnerHTML={{ __html: project.readmeHtml || "" }}
+      />
+    </Paper>
+  );
+}

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata, ResolvingMetadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { fetchGithubProjectBySlug } from "@/app/lib/github";
-import { Box, Container, Typography, Button, Chip, Stack, Paper, useTheme } from "@mui/material";
+import { Box, Container, Typography, Button, Chip, Stack, Paper } from "@mui/material";
 import { Star, GitFork, Calendar, Code2, ExternalLink, ArrowLeft, Tag, Bug } from "lucide-react";
 import { FaGithub } from "react-icons/fa";
 import { formatDistanceToNow } from "date-fns";
@@ -187,10 +187,10 @@ export default async function ProjectDetailPage(props: Props) {
                 label={project.language}
                 size="small"
                 sx={{
+                  height: 28,
                   backgroundColor: (t) => t.palette.primary.main + "15",
                   color: (t) => t.palette.primary.main,
-                  border: `1px solid ${t.palette.primary.main}30`,
-                  height: 28,
+                  border: (t) => `1px solid ${t.palette.primary.main}30`,
                 }}
               />
             )}
@@ -207,8 +207,16 @@ export default async function ProjectDetailPage(props: Props) {
 
           {/* Topics */}
           {project.topics.length > 0 && (
-            <Box sx={{ display: "flex", alignItems: "center", gap: 1, flexWrap: "wrap" }}>
-              <Tag size={14} color={(theme) => theme.palette.text.secondary as string} />
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+                flexWrap: "wrap",
+                color: "text.secondary",
+              }}
+            >
+              <Tag size={14} />
               <Stack direction="row" spacing={0.5} flexWrap="wrap">
                 {project.topics.map((topic) => (
                   <Chip
@@ -220,7 +228,7 @@ export default async function ProjectDetailPage(props: Props) {
                       fontSize: "0.7rem",
                       backgroundColor: (t) => t.palette.secondary.main + "10",
                       color: (t) => t.palette.secondary.main,
-                      border: `1px solid ${t.palette.secondary.main}30`,
+                      border: (t) => `1px solid ${t.palette.secondary.main}30`,
                     }}
                   />
                 ))}
@@ -301,7 +309,9 @@ function ReadmeSection({ project }: { project: Awaited<ReturnType<typeof fetchGi
           gap: 1,
         }}
       >
-        <Code2 size={16} color={(t) => t.palette.primary.main as string} />
+        <Box component="span" sx={{ display: "inline-flex", color: "primary.main" }}>
+          <Code2 size={16} />
+        </Box>
         <Typography variant="body2" fontWeight={600}>
           README
         </Typography>

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,7 +1,10 @@
-import type { Metadata, ResolvingMetadata } from "next";
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { fetchGithubProjectBySlug } from "@/app/lib/github";
+import {
+  fetchGithubProjectBySlug,
+  type GithubProjectDetail,
+} from "@/app/lib/github";
 import { Box, Container, Typography, Button, Chip, Stack, Paper } from "@mui/material";
 import { Star, GitFork, Calendar, Code2, ExternalLink, ArrowLeft, Tag, Bug } from "lucide-react";
 import { FaGithub } from "react-icons/fa";
@@ -18,10 +21,7 @@ export async function generateStaticParams() {
 
 export const dynamic = "force-dynamic";
 
-export async function generateMetadata(
-  props: Props,
-  parent: ResolvingMetadata
-): Promise<Metadata> {
+export async function generateMetadata(props: Props): Promise<Metadata> {
   try {
     const params = await props.params;
     const slug = params?.slug;
@@ -36,7 +36,9 @@ export async function generateMetadata(
     return {
       title: `${project.name} - Tyler Witlin`,
       description,
-      keywords: [...project.topics, project.language].filter(Boolean),
+      keywords: [...project.topics, project.language].filter(
+        (value): value is string => Boolean(value),
+      ),
       openGraph: {
         title: `${project.name} - Project Detail`,
         description,
@@ -287,7 +289,11 @@ function StatPill({ icon, label }: { icon: React.ReactNode; label: string }) {
   );
 }
 
-function ReadmeSection({ project }: { project: Awaited<ReturnType<typeof fetchGithubProjectBySlug>> & { readmeHtml: string } }) {
+function ReadmeSection({
+  project,
+}: {
+  project: GithubProjectDetail & { readmeHtml: string };
+}) {
   return (
     <Paper
       elevation={1}

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -131,7 +131,7 @@ export default async function ProjectDetailPage(props: Props) {
               </Typography>
             </Box>
 
-            <Stack direction="row" spacing={1} flexShrink={0}>
+            <Stack direction="row" spacing={1} sx={{ flexShrink: 0 }}>
               <Button
                 component="a"
                 href={project.htmlUrl}
@@ -175,9 +175,7 @@ export default async function ProjectDetailPage(props: Props) {
           <Stack
             direction="row"
             spacing={2}
-            flexWrap="wrap"
-            alignItems="center"
-            sx={{ mb: 3 }}
+            sx={{ mb: 3, flexWrap: "wrap", alignItems: "center" }}
           >
             <StatPill icon={<Star size={14} />} label={`${formatNumber(project.stars)} stars`} />
             <StatPill icon={<GitFork size={14} />} label={`${formatNumber(project.forks)} forks`} />
@@ -219,7 +217,7 @@ export default async function ProjectDetailPage(props: Props) {
               }}
             >
               <Tag size={14} />
-              <Stack direction="row" spacing={0.5} flexWrap="wrap">
+              <Stack direction="row" spacing={0.5} sx={{ flexWrap: "wrap" }}>
                 {project.topics.map((topic) => (
                   <Chip
                     key={topic}
@@ -318,7 +316,7 @@ function ReadmeSection({
         <Box component="span" sx={{ display: "inline-flex", color: "primary.main" }}>
           <Code2 size={16} />
         </Box>
-        <Typography variant="body2" fontWeight={600}>
+        <Typography variant="body2" sx={{ fontWeight: 600 }}>
           README
         </Typography>
       </Box>


### PR DESCRIPTION
- Add fuzzy search input on blog listing page: matches across title, excerpt, tags, content\n- Search combines AND-style with tag filters; both apply together\n- Shows result count context when filtering active\n- Add /projects/[slug] detail pages fetching GitHub repo metadata (stars, forks, language, topics)\n- Renders README as HTML on project detail page\n- Proper SEO metadata for projects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added searchable blog posts across titles, excerpts, tags, and content, with combined tag filtering and a clear-search option.
  * Added dedicated project detail pages with repository information, statistics, topics, status badges, and README content.
  * Added GitHub project retrieval with clear responses for missing or invalid projects.
* **Improvements**
  * Updated data loading to provide fresher blog and project information while maintaining caching.
  * Improved social sharing preview image typography and layout.
  * Simplified blog filtering controls by removing the filtered-result count display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds combined client-side blog search and tag filtering, plus dynamic project detail pages backed by GitHub repository metadata and sanitized README rendering.
- Adds cached blog and GitHub API responses.
- Adds a validated GitHub project-detail retrieval helper.
- Adds project metadata, statistics, links, topics, and README presentation.
- Corrects the previously reported search normalization and icon-property typing problems.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the missing helper is now exported with matching call signatures, search normalization is symmetric, and the invalid Lucide callback properties have been removed.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/lib/github.ts | Adds the previously missing validated project-detail helper, GitHub metadata mapping, sanitized README conversion, and safe URL handling. |
| src/app/projects/[slug]/page.tsx | Adds the dynamic project page and metadata generation while correcting the previously reported Lucide color-property typing issue. |
| src/app/blog/components/BlogView.tsx | Adds combined search and tag filtering with symmetric lowercase normalization, resolving the prior case-sensitive omission. |
| src/app/api/github/[slug]/route.ts | Adds a validated, cached project-detail API route using the newly exported GitHub helper. |
| src/app/api/blog/posts/route.ts | Adds shared-cache and stale-while-revalidate headers to successful blog-post responses. |
| src/app/blog/components/listing/PostFilterBar.tsx | Removes the redundant tag-only result count now supplied by the combined filtering view. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Visitor
    participant Page as Project Detail Page
    participant Helper as GitHub Helper
    participant GitHub as GitHub API
    Visitor->>Page: Open /projects/[slug]
    Page->>Helper: fetchGithubProjectBySlug(slug)
    Helper->>GitHub: Fetch repository metadata
    GitHub-->>Helper: Repository data
    Helper->>GitHub: Fetch README
    GitHub-->>Helper: Base64 Markdown
    Helper->>Helper: Convert and sanitize README HTML
    Helper-->>Page: Project detail or null
    alt Project exists
        Page-->>Visitor: Render metadata and README
    else Missing or invalid project
        Page-->>Visitor: Render not-found page
    end
```
</details>

<sub>Reviews (7): Last reviewed commit: ["fix(pr-574): cache blog posts, unify res..."](https://github.com/coolguy1771/witl-xyz/commit/a25eb8615611bd8a07e6665955b0f7682c1bc4d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50666912)</sub>

<!-- /greptile_comment -->