### PR TITLE
fix(build): unblock OG prerender and dynamic blog API

### DIFF
--- a/src/app/api/blog/posts/route.ts
+++ b/src/app/api/blog/posts/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAllPosts, getPostsByTags, getFeaturedPosts } from "@/app/lib/fs-blog";
 
-export const revalidate = 3600;
+export const dynamic = "force-dynamic";
 
 export async function GET(request: NextRequest) {
   try {

--- a/src/app/api/github/projects/route.ts
+++ b/src/app/api/github/projects/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { fetchGithubProjects } from "@/app/lib/github";
 
-export const revalidate = 3600;
+export const dynamic = "force-dynamic";
 
 const DEFAULT_USERNAME = "coolguy1771";
 const MAX_LIMIT = 20;

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -10,7 +10,15 @@ export const size = {
 export const contentType = "image/png";
 
 export default async function DefaultOpenGraphImage() {
-  const fontPath = path.join(process.cwd(), "src", "app", "fonts", "GeistMonoVF.woff");
+  // Satori cannot parse GeistMonoVF.woff (variable WOFF). Use a static TTF.
+  const fontPath = path.join(
+    process.cwd(),
+    "src",
+    "app",
+    "fonts",
+    "boot",
+    "DejaVuSansMono-Bold.ttf",
+  );
   const fontData = await fs.readFile(fontPath);
 
   return new ImageResponse(
@@ -27,15 +35,22 @@ export default async function DefaultOpenGraphImage() {
           flexDirection: "column",
           justifyContent: "center",
           alignItems: "center",
-          fontFamily: "'Geist Mono', monospace",
+          fontFamily: "'DejaVu Sans Mono'",
         }}
       >
-        <div style={{ textAlign: "center" }}>
-          <div style={{ fontSize: 72, marginBottom: 16, color: "#00d4ff" }}>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            textAlign: "center",
+          }}
+        >
+          <div style={{ display: "flex", fontSize: 72, marginBottom: 16, color: "#00d4ff" }}>
             witl@xyz:~$ whoami
           </div>
-          <div style={{ fontSize: 48, color: "#94a3b8" }}>Tyler Witlin</div>
-          <div style={{ fontSize: 28, marginTop: 16, color: "#3dd68c" }}>
+          <div style={{ display: "flex", fontSize: 48, color: "#94a3b8" }}>Tyler Witlin</div>
+          <div style={{ display: "flex", fontSize: 28, marginTop: 16, color: "#3dd68c" }}>
             DevOps Engineer @ Cisco Systems
           </div>
         </div>
@@ -45,7 +60,7 @@ export default async function DefaultOpenGraphImage() {
       ...size,
       fonts: [
         {
-          name: "Geist Mono",
+          name: "DejaVu Sans Mono",
           data: fontData,
           weight: 700,
         },


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Blog posts and GitHub project data now refresh dynamically, providing more current results.
* **Style**
  * Updated Open Graph image typography with improved font rendering.
  * Refined Open Graph image text alignment and layout for a more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes two API routes from hourly revalidation to dynamic execution to unblock builds and replaces the Open Graph image's unsupported variable WOFF with a static TTF.
- Forces the blog-post and GitHub-project API handlers to execute dynamically.
- Uses DejaVu Sans Mono Bold for Open Graph rendering and adds explicit flex layout styles.
- The GitHub route's dynamic execution removes upstream-request amortization and can exhaust GitHub API quotas.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The GitHub projects route should restore request caching or add application-level caching before merge because the new dynamic path can exhaust the upstream API quota and return empty project data.

Every Projects-section mount now executes an uncached GitHub API call, while upstream errors are silently converted into a successful empty response.

**Files Needing Attention:** src/app/api/github/projects/route.ts
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/api/blog/posts/route.ts | Replaces hourly revalidation with dynamic execution; no publishable defect was established for the filesystem-backed blog path. |
| src/app/api/github/projects/route.ts | Dynamic execution makes each Projects-section mount perform a fresh, rate-limited GitHub API request and can return an empty project list after quota exhaustion. |
| src/app/opengraph-image.tsx | Replaces the Satori-incompatible variable WOFF with an existing static TTF and adjusts the image layout for flex rendering. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Asrc%2Fapp%2Fapi%2Fgithub%2Fprojects%2Froute.ts%3A4%0A**Dynamic%20route%20exhausts%20GitHub%20quota**%0A%0AWhen%20visitors%20mount%20the%20Projects%20section%2C%20%60force-dynamic%60%20executes%20this%20handler%20and%20makes%20a%20new%20uncached%20GitHub%20API%20request%20for%20every%20page%20load.%20Once%20the%20shared%20upstream%20quota%20is%20exhausted%2C%20%60fetchGithubProjects%60%20converts%20the%20rate-limit%20error%20into%20an%20empty%20array%2C%20causing%20visitors%20to%20receive%20a%20successful%20but%20empty%20projects%20response%20until%20the%20quota%20recovers.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=578&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fapp%2Fapi%2Fgithub%2Fprojects%2Froute.ts%3A4%0A**Dynamic%20route%20exhausts%20GitHub%20quota**%0A%0AWhen%20visitors%20mount%20the%20Projects%20section%2C%20%60force-dynamic%60%20executes%20this%20handler%20and%20makes%20a%20new%20uncached%20GitHub%20API%20request%20for%20every%20page%20load.%20Once%20the%20shared%20upstream%20quota%20is%20exhausted%2C%20%60fetchGithubProjects%60%20converts%20the%20rate-limit%20error%20into%20an%20empty%20array%2C%20causing%20visitors%20to%20receive%20a%20successful%20but%20empty%20projects%20response%20until%20the%20quota%20recovers.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=coolguy1771%2Fwitl-xyz&pr=578&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22coolguy1771%2Fwitl-xyz%22%20on%20the%20existing%20branch%20%22fix%2Fog-prerender-build%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fog-prerender-build%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fapp%2Fapi%2Fgithub%2Fprojects%2Froute.ts%3A4%0A**Dynamic%20route%20exhausts%20GitHub%20quota**%0A%0AWhen%20visitors%20mount%20the%20Projects%20section%2C%20%60force-dynamic%60%20executes%20this%20handler%20and%20makes%20a%20new%20uncached%20GitHub%20API%20request%20for%20every%20page%20load.%20Once%20the%20shared%20upstream%20quota%20is%20exhausted%2C%20%60fetchGithubProjects%60%20converts%20the%20rate-limit%20error%20into%20an%20empty%20array%2C%20causing%20visitors%20to%20receive%20a%20successful%20but%20empty%20projects%20response%20until%20the%20quota%20recovers.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=coolguy1771%2Fwitl-xyz&pr=578&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/app/api/github/projects/route.ts:4
**Dynamic route exhausts GitHub quota**

When visitors mount the Projects section, `force-dynamic` executes this handler and makes a new uncached GitHub API request for every page load. Once the shared upstream quota is exhausted, `fetchGithubProjects` converts the rate-limit error into an empty array, causing visitors to receive a successful but empty projects response until the quota recovers.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(build): use TTF for OG images and ma..."](https://github.com/coolguy1771/witl-xyz/commit/98dc6eafd66832a4c382c84b47477e524c0a2148) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52328063)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->