### PR TITLE
Update role to Platform Engineer at CentralReach

### DIFF
--- a/src/app/api/blog/rss/route.ts
+++ b/src/app/api/blog/rss/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 
 const SITE_URL = "https://witl.xyz";
 const FEED_TITLE = "Tyler Witlin - Blog";
-const FEED_DESC = "Blog posts by Tyler Witlin - DevOps Engineer specializing in Kubernetes, GitOps, CI/CD pipelines, and cloud-native infrastructure.";
+const FEED_DESC = "Blog posts by Tyler Witlin - Platform Engineer specializing in Kubernetes, GitOps, CI/CD pipelines, and cloud-native infrastructure.";
 
 export const revalidate = 3600; // ISR: regenerate every hour
 

--- a/src/app/components/About.tsx
+++ b/src/app/components/About.tsx
@@ -78,8 +78,8 @@ export const AboutSection: React.FC = () => {
               >
                 Kubernetes
               </Box>{" "}
-              for a living. Right now that means CI/CD infrastructure at Cisco on OpenShift; before
-              that it was{" "}
+              for a living. Right now that means platform engineering at CentralReach; before that
+              it was CI/CD on OpenShift at Cisco, then{" "}
               <Box
                 component="span"
                 sx={{ color: theme.palette.primary.main, fontWeight: 600 }}

--- a/src/app/components/Contact.tsx
+++ b/src/app/components/Contact.tsx
@@ -90,8 +90,8 @@ export const ContactSection: React.FC = () => {
               lineHeight: 1.7,
             }}
           >
-            Open to DevOps and SRE roles. I&apos;ve spent most of my career in air-gapped
-            environments and I&apos;m not scared off by compliance requirements.
+            I&apos;m a Platform Engineer at CentralReach. I&apos;ve spent most of my career in
+            air-gapped environments and I&apos;m not scared off by compliance requirements.
           </Typography>
 
           <MotionBox variants={popIn}>

--- a/src/app/components/Hero.tsx
+++ b/src/app/components/Hero.tsx
@@ -12,7 +12,7 @@ const TERMINAL_LINES = [
   { type: "output", text: "Tyler Witlin" },
   { type: "blank", text: "" },
   { type: "prompt", text: "cat role.txt" },
-  { type: "output-highlight", text: "DevOps Engineer @ Cisco Systems" },
+  { type: "output-highlight", text: "Platform Engineer @ CentralReach" },
   { type: "blank", text: "" },
   { type: "prompt", text: "kubectl get specialties --no-headers" },
   { type: "output-green", text: "openshift    argocd    helm    golang    air-gapped" },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,9 +21,9 @@ const geistMono = localFont({
 });
 
 export const metadata: Metadata = {
-  title: "Tyler Witlin - DevOps Engineer",
+  title: "Tyler Witlin - Platform Engineer",
   description:
-    "DevOps Engineer specializing in Kubernetes, GitOps, CI/CD pipelines, and cloud-native infrastructure. CKA certified.",
+    "Platform Engineer at CentralReach specializing in Kubernetes, GitOps, CI/CD pipelines, and cloud-native infrastructure. CKA certified.",
 };
 
 export const viewport: Viewport = {

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -51,7 +51,7 @@ export default async function DefaultOpenGraphImage() {
           </div>
           <div style={{ display: "flex", fontSize: 48, color: "#94a3b8" }}>Tyler Witlin</div>
           <div style={{ display: "flex", fontSize: 28, marginTop: 16, color: "#3dd68c" }}>
-            DevOps Engineer @ Cisco Systems
+            Platform Engineer @ CentralReach
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Content Updates**
  - Updated professional titles and employment details across the website.
  - Revised career history to reflect platform engineering work at CentralReach, previous experience at Cisco, and work with air-gapped clusters at General Dynamics.
  - Updated contact messaging to reflect the current Platform Engineer role.
  - Updated RSS and social sharing descriptions with the latest professional information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates the site’s professional biography from DevOps Engineer at Cisco to Platform Engineer at CentralReach.
- Refreshes visible role and employer copy in the hero, About, and Contact sections.
- Aligns page metadata, RSS metadata, and the generated Open Graph image with the new role.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with all changed public-facing role information remaining consistent.

The changes are limited to coherent biographical and metadata copy updates, with no accepted functional, security, or quality defects.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/app/api/blog/rss/route.ts | Updates the RSS feed description to use the new Platform Engineer title. |
| src/app/components/About.tsx | Adds CentralReach as the current employer while preserving a coherent reverse-chronological employment summary. |
| src/app/components/Contact.tsx | Replaces the job-search statement with the current Platform Engineer role. |
| src/app/components/Hero.tsx | Updates the terminal-style role output to Platform Engineer at CentralReach. |
| src/app/layout.tsx | Aligns the page title and metadata description with the new role and employer. |
| src/app/opengraph-image.tsx | Updates the generated social-sharing image with the new role and employer. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: update role to Platform Engineer a..."](https://github.com/coolguy1771/witl-xyz/commit/4bc19b7781cff952f600022ac47c92e7d64f5c6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52329289)</sub>

<!-- /greptile_comment -->